### PR TITLE
Fix for stale connections to retry a query after a reconnect

### DIFF
--- a/lib/data_stores/mysql_data_store.py
+++ b/lib/data_stores/mysql_data_store.py
@@ -81,12 +81,14 @@ class MySQLConnection(object):
   def Execute(self, *args):
     try:
       self.cursor.execute(*args)
-
       return self.cursor.fetchall()
-    except MySQLdb.Error:
-      # If the connection becomes stale we reconnect.
+    except MySQLdb.Error:  
       self._MakeConnection(database=config_lib.CONFIG["Mysql.database_name"])
-      raise
+      try:
+        self.cursor.execute(*args)
+        return self.cursor.fetchall()
+      except MySQLdb.Error:
+        raise
 
 
 class ConnectionPool(object):


### PR DESCRIPTION
MySQL will terminate inactive connections so the UI will frequently give server errors until the page has been refreshed enough times to reconnect all the connections in the pool.  

As of this fix we are able to run configure multiple worker and frontend processes using MySQL without them all crashing.  Something else may have corrected that, but after this fix we tested again and it no longer fails.  We observed similar problems as Issue #30 prior to this.
