### PR TITLE
Fix issue when deploying linux client with no output parameter

### DIFF
--- a/client/client_build.py
+++ b/client/client_build.py
@@ -212,14 +212,20 @@ def main(_):
                      config_lib.CONFIG.Get("ClientBuilder.template_path",
                                            context=deployer.context))
 
-    # If output filename isn't specified, write to args.outputdir with a
-    # .deployed extension so we can distinguish it from repacked binaries.
-    filename = ".".join(
-        (config_lib.CONFIG.Get("ClientBuilder.output_filename",
-                               context=deployer.context), "deployed"))
+    # If neither output filename or output directory is specified,
+    # use the default location from the config file.
+    output = None
+    if args.output:
+      output = args.output
+    elif args.outputdir:
+      # If output filename isn't specified, write to args.outputdir with a
+      # .deployed extension so we can distinguish it from repacked binaries.
+      filename = ".".join(
+          (config_lib.CONFIG.Get("ClientBuilder.output_filename",
+                                 context=deployer.context), "deployed"))
+      output = os.path.join(args.outputdir, filename)
 
-    deployer.MakeDeployableBinary(template_path, args.output or os.path.join(
-        args.outputdir, filename))
+    deployer.MakeDeployableBinary(template_path, output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When deploying the linux client, if neither the `output` nor the `outputdir` parameter is specified, the `.deb` file is written in a temporary directory and deleted at the end of the execution. The execution finishes normally without any error message.
This issue appeared with the new `outputdir` parameter in 71edc3e4.

This pull request should solve this: if neither `output` nor `outputdir` is specified, `None` is passed as the output parameter to `deployer.MakeDeployableBinary()`. Thus, the default location from the configuration is used (`ClientBuilder.output_path` in [build.py](https://github.com/google/grr/blob/master/lib/build.py#L580-L582)). This was the default behaviour prior to 71edc3e4.

/cc @destijl 
