### PR TITLE
Mock smtplib. Skip mysql tests if no DB.

### DIFF
--- a/lib/data_stores/mysql_data_store_test.py
+++ b/lib/data_stores/mysql_data_store_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """Tests the mysql data store."""
-
+import unittest
 
 # pylint: disable=unused-import,g-bad-import-order
 from grr.lib import server_plugins
@@ -18,6 +18,9 @@ from grr.lib.data_stores import mysql_data_store
 class MysqlTestMixin(object):
 
   def InitDatastore(self):
+    if config_lib.CONFIG.Get("Mysql.port") == 0:
+      raise unittest.SkipTest("Skipping since Mysql.port is set to 0.")
+
     self.token = access_control.ACLToken(username="test",
                                          reason="Running tests")
     # Use separate tables for benchmarks / tests so they can be run in parallel.

--- a/lib/email_alerts_test.py
+++ b/lib/email_alerts_test.py
@@ -19,56 +19,55 @@ class SendEmailTests(test_lib.GRRBaseTest):
   def testSendEmail(self):
     testdomain = "test.com"
     config_lib.CONFIG.Set("Email.default_domain", testdomain)
-    with mock.patch.object(smtplib, "SMTP") as mock_smtp:
-      smtp_conn = mock_smtp.return_value
+    smtp_conn = self.mock_smtp.return_value
 
-      # Single fully qualified address
-      to_address = "testto@example.com"
-      from_address = "me@example.com"
-      subject = "test"
-      message = ""
-      email_alerts.SendEmail(to_address, from_address, subject, message)
-      c_from, c_to, msg = smtp_conn.sendmail.call_args[0]
-      self.assertEqual(from_address, c_from)
-      self.assertEqual([to_address], c_to)
-      self.assertFalse("CC:" in msg)
+    # Single fully qualified address
+    to_address = "testto@example.com"
+    from_address = "me@example.com"
+    subject = "test"
+    message = ""
+    email_alerts.SendEmail(to_address, from_address, subject, message)
+    c_from, c_to, msg = smtp_conn.sendmail.call_args[0]
+    self.assertEqual(from_address, c_from)
+    self.assertEqual([to_address], c_to)
+    self.assertFalse("CC:" in msg)
 
-      # Multiple unqualified to addresses, one cc
-      to_address = "testto,abc,def"
-      to_address_expected = [
-          x + testdomain for x in ["testto@", "abc@", "def@"]]
-      cc_address = "testcc"
-      email_alerts.SendEmail(to_address, from_address, subject, message,
-                             cc_addresses=cc_address)
-      c_from, c_to, message = smtp_conn.sendmail.call_args[0]
-      self.assertEqual(from_address, c_from)
-      self.assertEqual(to_address_expected, c_to)
-      self.assertTrue("CC: testcc@%s" % testdomain in message)
+    # Multiple unqualified to addresses, one cc
+    to_address = "testto,abc,def"
+    to_address_expected = [
+        x + testdomain for x in ["testto@", "abc@", "def@"]]
+    cc_address = "testcc"
+    email_alerts.SendEmail(to_address, from_address, subject, message,
+                            cc_addresses=cc_address)
+    c_from, c_to, message = smtp_conn.sendmail.call_args[0]
+    self.assertEqual(from_address, c_from)
+    self.assertEqual(to_address_expected, c_to)
+    self.assertTrue("CC: testcc@%s" % testdomain in message)
 
-      # Multiple unqualified to addresses, two cc, message_id set
-      to_address_expected = [
-          x + testdomain for x in ["testto@", "abc@", "def@"]]
-      cc_address = "testcc,testcc2"
-      email_msg_id = "123123"
-      email_alerts.SendEmail(to_address, from_address, subject, message,
-                             cc_addresses=cc_address, message_id=email_msg_id)
-      c_from, c_to, message = smtp_conn.sendmail.call_args[0]
-      self.assertEqual(from_address, c_from)
-      self.assertEqual(to_address_expected, c_to)
-      self.assertTrue("CC: testcc@%s,testcc2@%s" % (testdomain, testdomain) in
-                      message)
-      self.assertTrue("Message-ID: %s" % email_msg_id)
+    # Multiple unqualified to addresses, two cc, message_id set
+    to_address_expected = [
+        x + testdomain for x in ["testto@", "abc@", "def@"]]
+    cc_address = "testcc,testcc2"
+    email_msg_id = "123123"
+    email_alerts.SendEmail(to_address, from_address, subject, message,
+                            cc_addresses=cc_address, message_id=email_msg_id)
+    c_from, c_to, message = smtp_conn.sendmail.call_args[0]
+    self.assertEqual(from_address, c_from)
+    self.assertEqual(to_address_expected, c_to)
+    self.assertTrue("CC: testcc@%s,testcc2@%s" % (testdomain, testdomain) in
+                    message)
+    self.assertTrue("Message-ID: %s" % email_msg_id)
 
-      # Multiple unqualified to addresses, two cc, no default domain
-      to_address_expected = ["testto", "abc", "def"]
-      config_lib.CONFIG.Set("Email.default_domain", None)
-      email_alerts.SendEmail(to_address, from_address, subject, message,
-                             cc_addresses=cc_address)
-      c_from, c_to, message = smtp_conn.sendmail.call_args[0]
-      self.assertEqual(from_address, c_from)
-      self.assertEqual(to_address_expected, c_to)
-      self.assertTrue("CC: testcc@%s,testcc2@%s" % (testdomain, testdomain) in
-                      message)
+    # Multiple unqualified to addresses, two cc, no default domain
+    to_address_expected = ["testto", "abc", "def"]
+    config_lib.CONFIG.Set("Email.default_domain", None)
+    email_alerts.SendEmail(to_address, from_address, subject, message,
+                            cc_addresses=cc_address)
+    c_from, c_to, message = smtp_conn.sendmail.call_args[0]
+    self.assertEqual(from_address, c_from)
+    self.assertEqual(to_address_expected, c_to)
+    self.assertTrue("CC: testcc@%s,testcc2@%s" % (testdomain, testdomain) in
+                    message)
 
 
 def main(argv):


### PR DESCRIPTION
- Mock out smtplib.SMTP so we don't send email during tests
- Change test_lib to handle test skips in setUp
- Skip mysql tests if port == 0, this seems to be the best indicator of whether
  you have configured a DB or not. This avoids tests failing if you have the
  mysql client library installed but no actual database present.
