### PR TITLE
Fixed missing TypeError exception

### DIFF
--- a/parsers/wmi_parser.py
+++ b/parsers/wmi_parser.py
@@ -101,12 +101,12 @@ class WMILogicalDisksParser(parsers.WMIQueryParser):
 
     try:
       size = int(result.get("Size"))
-    except ValueError:
+    except (ValueError, TypeError):
       size = None
 
     try:
       free_space = int(result.get("FreeSpace"))
-    except ValueError:
+    except (ValueError, TypeError):
       free_space = None
 
     # Since we don't get the sector sizes from WMI, we just set them at 1 byte


### PR DESCRIPTION
Workers/Enrollers can get hung up if this is not properly handled.  I'm not sure if this was just a missing TypeError or if there is some other behavior that is causing the WMI disk stuff to have TypeError instead of ValueError.  result.get("Size") will return None and then int() fails with TypeError as described here: https://github.com/google/grr/issues/87

This fix appears to top the WMI disk artifacts from causing worker/enroller hangups.