### PR TITLE
Add -E to sudo easy_install selenium

### DIFF
--- a/scripts/install_script_ubuntu.sh
+++ b/scripts/install_script_ubuntu.sh
@@ -160,7 +160,7 @@ run_cmd_confirm sudo apt-get --yes remove python-psutil;
 run_cmd_confirm sudo pip install psutil --upgrade
 
 header "Installing Selenium test framework for Tests"
-run_cmd_confirm sudo easy_install selenium
+run_cmd_confirm sudo -E easy_install selenium
 
 
 header "Installing correct Django version."


### PR DESCRIPTION
This was required so that I could pass the http[s]_proxy environment vars to easy_install.