### PR TITLE
Basic travis build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 proto/*_pb2.py
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+proto/*_pb2.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
   - "2.7"
 before_install: /bin/bash before_install.sh
 install: /bin/bash install.sh
-script: cd ..; PYTHONPATH=. python grr/run_tests.py --processes=1
+script: /bin/bash run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ virtualenv:
 language: python
 python:
   - "2.7"
+before_install: /bin/bash before_install.sh
 install: /bin/bash install.sh
 script: cd ..; PYTHONPATH=. python grr/run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
   - "2.7"
 before_install: /bin/bash before_install.sh
 install: /bin/bash install.sh
-script: cd ..; PYTHONPATH=. python grr/run_tests.py
+script: cd ..; PYTHONPATH=. python grr/run_tests.py --processes=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,5 @@ virtualenv:
 language: python
 python:
   - "2.7"
-install:
-  - "pip install -r requirements.txt"
-  - "cd proto; make"
-  - "cd artifacts; make"
+install: /bin/bash install.sh
 script: cd ..; PYTHONPATH=. python grr/run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+virtualenv:
+  system_site_packages: true
+language: python
+python:
+  - "2.7"
+install:
+  - "pip install -r requirements.txt"
+  - "cd proto; make"
+  - "cd artifacts; make"
+script: cd ..; PYTHONPATH=. python grr/run_tests.py

--- a/artifacts/Makefile
+++ b/artifacts/Makefile
@@ -8,7 +8,7 @@ all: sync
 
 sync:
 	git clone https://github.com/ForensicArtifacts/artifacts.git $(TEMPDIR)
-	-rm *.yaml
+	-rm -f *.yaml
 
 	cp $(TEMPDIR)/definitions/*.yaml .
 
@@ -17,4 +17,4 @@ sync:
 .PHONY: sync clean
 
 clean:
-	-rm *.yaml
+	-rm -f *.yaml

--- a/before_install.sh
+++ b/before_install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+sudo apt-get install python-protobuf libprotoc-dev protobuf-compiler m2crypto python-support libdistorm64-1 libdistorm64-dev python-psutil pytsk3 ncurses-dev python-pip
+
+PLAT=amd64
+DEB_DEPENDENCIES_URL=https://googledrive.com/host/0B1wsLqFoT7i2aW5mWXNDX1NtTnc/ubuntu-12.04-${PLAT}-debs.tar.gz
+DEB_DEPENDENCIES_DIR=ubuntu-12.04-${PLAT}-debs
+SLEUTHKIT_DEB=sleuthkit-lib_3.2.3-1_${PLAT}.deb
+
+DEB_DEPENDENCIES_TARBALL=$(basename ${DEB_DEPENDENCIES_URL})
+wget --no-verbose ${DEB_DEPENDENCIES_URL} -O ${DEB_DEPENDENCIES_TARBALL}
+tar zxfv ${DEB_DEPENDENCIES_TARBALL}
+sudo dpkg -i ${DEB_DEPENDENCIES_DIR}/${SLEUTHKIT_DEB}

--- a/before_install.sh
+++ b/before_install.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
-sudo apt-get install python-protobuf libprotoc-dev protobuf-compiler m2crypto python-support libdistorm64-1 libdistorm64-dev python-psutil pytsk3 ncurses-dev python-pip
+PROTO_PACKAGES=(libprotobuf9_2.6.1-1ppa1~precise_amd64.deb libprotobuf-lite9_2.6.1-1ppa1~precise_amd64.deb libprotobuf-dev_2.6.1-1ppa1~precise_amd64.deb libprotobuf-java_2.6.1-1ppa1~precise_all.deb libprotoc9_2.6.1-1ppa1~precise_amd64.deb libprotoc-dev_2.6.1-1ppa1~precise_amd64.deb protobuf-compiler_2.6.1-1ppa1~precise_amd64.deb python-protobuf_2.6.1-1ppa1~precise_amd64.deb)
+
+mkdir protobuf-debs
+cd protobuf-debs
+
+echo "Installing protobuf debs"
+for i in ${PROTO_PACKAGES[@]}; do
+  echo "Downloading custom package $i"
+  wget https://dionyziz.com/protobuf-debs/$i
+  echo "Installing $i"
+  sudo dpkg -i $i
+done
+cd ..
+echo "Protobuf debs installed"
+
+sudo apt-get install m2crypto python-support libdistorm64-1 libdistorm64-dev python-psutil pytsk3 ncurses-dev python-pip
 
 PLAT=amd64
 DEB_DEPENDENCIES_URL=https://googledrive.com/host/0B1wsLqFoT7i2aW5mWXNDX1NtTnc/ubuntu-12.04-${PLAT}-debs.tar.gz

--- a/before_install.sh
+++ b/before_install.sh
@@ -14,6 +14,9 @@ done
 cd ..
 echo "Protobuf debs installed"
 
+sudo apt-get install python-software-properties
+sudo add-apt-repository ppa:kristinn-l/plaso-dev -y
+sudo apt-get update -q
 sudo apt-get install m2crypto python-support libdistorm64-1 libdistorm64-dev python-psutil pytsk3 ncurses-dev python-pip
 
 PLAT=amd64

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 pip install -r requirements.txt
-sudo apt-get install python-protobuf libprotoc-dev protobuf-compiler m2crypto python-support libdistorm64-1 libdistorm64-dev python-psutil pytsk3 ncurses-dev python-pip
-
-PLAT=amd64
-DEB_DEPENDENCIES_URL=https://googledrive.com/host/0B1wsLqFoT7i2aW5mWXNDX1NtTnc/ubuntu-12.04-${PLAT}-debs.tar.gz
-DEB_DEPENDENCIES_DIR=ubuntu-12.04-${PLAT}-debs
-SLEUTHKIT_DEB=sleuthkit-lib_3.2.3-1_${PLAT}.deb
-
-DEB_DEPENDENCIES_TARBALL=$(basename ${DEB_DEPENDENCIES_URL})
-wget --no-verbose ${DEB_DEPENDENCIES_URL} -O ${DEB_DEPENDENCIES_TARBALL}
-tar zxfv ${DEB_DEPENDENCIES_TARBALL}
-sudo dpkg -i ${DEB_DEPENDENCIES_DIR}/${SLEUTHKIT_DEB}
 
 echo "Compiling proto files..."
 echo "protoc version:"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+pip install -r requirements.txt
+sudo apt-get install python-protobuf libprotoc-dev protobuf-compiler m2crypto python-support libdistorm64-1 libdistorm64-dev python-psutil pytsk3 ncurses-dev python-pip
+
+PLAT=amd64
+DEB_DEPENDENCIES_URL=https://googledrive.com/host/0B1wsLqFoT7i2aW5mWXNDX1NtTnc/ubuntu-12.04-${PLAT}-debs.tar.gz
+DEB_DEPENDENCIES_DIR=ubuntu-12.04-${PLAT}-debs
+SLEUTHKIT_DEB=sleuthkit-lib_3.2.3-1_${PLAT}.deb
+
+DEB_DEPENDENCIES_TARBALL=$(basename ${DEB_DEPENDENCIES_URL})
+wget --no-verbose ${DEB_DEPENDENCIES_URL} -O ${DEB_DEPENDENCIES_TARBALL}
+tar zxfv ${DEB_DEPENDENCIES_TARBALL}
+sudo dpkg -i ${DEB_DEPENDENCIES_DIR}/${SLEUTHKIT_DEB}
+
+echo "Compiling proto files..."
+echo "protoc version:"
+protoc --version
+cd proto
+echo "Running make in proto dir..."
+pwd
+make
+cd ..
+
+echo "Compiling artifact files..."
+cd artifacts
+echo "Running make in artifacts dir..."
+pwd
+make
+cd ..

--- a/lib/test_lib.py
+++ b/lib/test_lib.py
@@ -7,6 +7,8 @@ import codecs
 import datetime
 import functools
 import itertools
+import logging
+import mock
 import os
 import pdb
 import re
@@ -25,15 +27,10 @@ import urlparse
 
 from M2Crypto import X509
 
-import mock
-
 from selenium.common import exceptions
 from selenium.webdriver.common import action_chains
 from selenium.webdriver.common import keys
 from selenium.webdriver.support import select
-
-import logging
-import unittest
 
 from grr.client import actions
 from grr.client import comms

--- a/lib/test_lib.py
+++ b/lib/test_lib.py
@@ -2030,7 +2030,15 @@ class FakeTestDataVFSHandler(ClientVFSHandlerFixture):
 
 
 class GrrTestProgram(unittest.TestProgram):
-  """A Unit test program which is compatible with conf based args parsing."""
+  """A Unit test program which is compatible with conf based args parsing.
+
+  This program ignores the testLoader passed to it and implements its
+  own test loading behavior in case the --tests argument was specified
+  when the program is ran. It magically reads from the --tests argument.
+
+  In case no --tests argument was specified, the program uses the test
+  loader to load the tests.
+  """
 
   def __init__(self, labels=None, **kw):
     self.labels = labels

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ mock==1.0.1
 mox==0.5.3
 numpy==1.9.1
 pandas==0.13.1
-protobuf==2.6.0
 psutil==2.1.3
 pyaml==14.12.10
 pycrypto==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,11 @@ greenlet==0.4.5
 ipaddr==2.1.11
 ipython==2.3.1
 itsdangerous==0.24
+matplotlib==1.3.1
 mock==1.0.1
 mox==0.5.3
 numpy==1.9.1
+pandas==0.13.1
 protobuf==2.6.0
 psutil==2.1.3
 pyaml==14.12.10

--- a/run_tests.py
+++ b/run_tests.py
@@ -182,7 +182,7 @@ def main(argv=None):
     processes = {}
     print "Running tests with labels %s" % ",".join(flags.FLAGS.labels)
 
-    with utils.TempDirectory() as flags.FLAGS.temp_dir:
+    with utils.TempDirectory() as temp_dir:
       start = time.time()
       labels = set(flags.FLAGS.labels)
 
@@ -190,7 +190,7 @@ def main(argv=None):
         if labels and not DoesTestHaveLabels(cls, labels):
           continue
 
-        result_filename = os.path.join(flags.FLAGS.temp_dir, name)
+        result_filename = os.path.join(temp_dir, name)
 
         argv = [sys.executable] + sys.argv[:]
         if "--output" not in argv:

--- a/run_tests.py
+++ b/run_tests.py
@@ -175,6 +175,7 @@ def main(argv=None):
 
     suites = flags.FLAGS.tests or test_lib.GRRBaseTest.classes
     for test_suite in suites:
+      print "Running test %s" % test_suite
       RunTest(test_suite, stream=stream)
 
   else:

--- a/run_tests.py
+++ b/run_tests.py
@@ -84,6 +84,20 @@ class GRREverythingTestLoader(test_lib.GRRTestLoader):
 
 
 def RunTest(test_suite, stream=None):
+  """Run an individual test.
+
+     Ignore the argument test_suite passed to this function, then
+     magically acquire an individual test name as specified by the --tests
+     flag, run it, and then exit the whole Python program completely.
+
+     Args:
+       test_suite (string): Ignored.
+       stream: The stream to print results to.
+
+      Returns:
+        This function does not return; it causes a program exit.
+     """
+
   out_fd = stream
   if stream:
     out_fd = StringIO.StringIO()

--- a/run_tests.py
+++ b/run_tests.py
@@ -198,10 +198,10 @@ def main(argv=None):
                               "processing mode, but %i were specified" %
                               len(suites))
 
-    for test_suite in suites:
-      print "Running test %s" % test_suite
-      sys.stdout.flush()
-      RunTest(test_suite, stream=stream)
+    test_suite = suites[0]
+    print "Running test %s" % test_suite
+    sys.stdout.flush()
+    RunTest(test_suite, stream=stream)
 
   else:
     processes = {}

--- a/run_tests.py
+++ b/run_tests.py
@@ -194,6 +194,10 @@ def main(argv=None):
 
     suites = flags.FLAGS.tests or test_lib.GRRBaseTest.classes
 
+    assert len(suites) == 1, ("Only a single test is supported in single "
+                              "processing mode, but %i were specified" %
+                              len(suites))
+
     for test_suite in suites:
       print "Running test %s" % test_suite
       sys.stdout.flush()

--- a/run_tests.py
+++ b/run_tests.py
@@ -103,12 +103,23 @@ def RunTest(test_suite, stream=None):
     out_fd = StringIO.StringIO()
 
   try:
+    # Here we use a GRREverythingTestLoader to load tests from.
+    # However, the fact that GRREverythingTestLoader loads all
+    # tests is irrelevant, because GrrTestProgram simply reads
+    # from the --tests flag passed to the program, so not all
+    # tests are ran. Only the test specified via --tests will
+    # be ran. Because --tests supports only one test at a time
+    # this will cause only an individual test to be ran.
+    # GrrTestProgram then terminates the execution of the whole
+    # python program using sys.exit() so this function does not
+    # return.
     test_lib.GrrTestProgram(argv=[sys.argv[0], test_suite],
                             testLoader=GRREverythingTestLoader(
                                 labels=flags.FLAGS.labels),
                             testRunner=unittest.TextTestRunner(
                                 stream=out_fd))
   finally:
+    # Clean up before the program exits.
     if stream:
       stream.write("Test name: %s\n" % test_suite)
       stream.write(out_fd.getvalue())

--- a/run_tests.py
+++ b/run_tests.py
@@ -173,7 +173,7 @@ def DoesTestHaveLabels(cls, labels):
 
 
 def main(argv=None):
-  if flags.FLAGS.tests or flags.FLAGS.processes == 1:
+  if flags.FLAGS.tests:
     print "Running test in single process mode..."
 
     stream = sys.stderr

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd ..
+echo 'Running tests...'
+PYTHONPATH=. python grr/run_tests.py --processes=1 2>&1|grep -v 'DEBUG:'|grep -v 'INFO:'

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,3 +4,5 @@ echo 'Running tests...'
 
 EXCLUDE_TESTS=HTTPDataStoreCSVBenchmarks,HTTPDataStoreBenchmarks,MicroBenchmarks,TDBDataStoreBenchmarks,FakeDataStoreBenchmarks,AverageMicroBenchmarks,SqliteDataStoreBenchmarks,DataStoreCSVBenchmarks,TDBDataStoreCSVBenchmarks,AFF4Benchmark
 PYTHONPATH=. python grr/run_tests.py --processes=1 --exclude_tests=$EXCLUDE_TESTS 2>&1|grep -v 'DEBUG:'|grep -v 'INFO:'
+TEST_STATUS=${PIPESTATUS[0]}
+exit $TEST_STATUS

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 cd ..
 echo 'Running tests...'
-PYTHONPATH=. python grr/run_tests.py --processes=1 2>&1|grep -v 'DEBUG:'|grep -v 'INFO:'
+
+EXCLUDE_TESTS=HTTPDataStoreCSVBenchmarks,HTTPDataStoreBenchmarks,MicroBenchmarks,TDBDataStoreBenchmarks,FakeDataStoreBenchmarks,AverageMicroBenchmarks,SqliteDataStoreBenchmarks,DataStoreCSVBenchmarks,TDBDataStoreCSVBenchmarks,AFF4Benchmark
+PYTHONPATH=. python grr/run_tests.py --processes=1 --exclude_tests=$EXCLUDE_TESTS 2>&1|grep -v 'DEBUG:'|grep -v 'INFO:'


### PR DESCRIPTION
This pull request introduces a first version of the travis build. It makes the necessary changes required to get this running on travis systems.

I'm introducing two separate installation scripts that are responsible for different stages of setting up the grr environment in order to be able to run it on travis:

* `before_install.sh` installs all the necessary dependencies on the vanilla travis system. This includes ubuntu repository `apt-get install` commands and `apt-get install` commands from `plaso`,  and some manual installation of `.deb` files. These are explained in detail below.

* `install.sh` fires up the `pip` installation of packages and runs the required `make` command on the pure source in order to do the necessary building for artifacts and protobufs.

The several `apt-get install` commands from the official ubuntu repositories are mostly taken from the previous installation script that was available before this PR. However, additional packages had to be introduced, as the travis environment is a relatively clean ubuntu environment which is missing a lot of libraries. The travis environment also runs Ubuntu 12.04. This has some minor incompatibilities compared to Ubuntu 14.04 which is what the previous installation script was written for.

Some `apt-get install` commands from the `plaso` repository are required for packages that are not available in the regular ubuntu repositories (or do not include patches we need), such as m2crypto and pytsk.

The `pip` installation is based on the newly introduced `requirements.txt` file which has been separated out. These used to work with `apt-get`, but having a requirements.txt file is a better practice for python packages. The new requirements.txt has already been merged in my previous pull request #100 which was cherry-picked from this pull request, so only minor changes in that file are visible in this PR.

I'm also introducing the `run_tests.sh` which is used to run all the python unit tests. This is needed to include a black-list of excluded tests. The rationale behind excluded tests is to start with a minimal travis build and go from there. We can start adding more tests as we go. However, as travis will be used to evaluate external pull-requests, it's important that we use a black list instead of a white list.

The `run_tests.sh` file also filters out verbose error messages using `grep`. This is needed as travis runs out of both buffer sizes if we don't apply it. The two buffer sizes are the visible buffer (on the travis website) and the download buffer (for when downloading the log). Travis thinks a huge log indicates an infinite loop, so we have to keep our logging somewhat limited. While this should be fixed at the python logging module level, it's currently easier to achieve it with a grep, as there's some awkward things going on with config files in the test runner.

run_tests.py has been modified to include some bug fixes and work-arounds. While it is not perfect, it's a first step in getting this up. Additional bugfixes will be coming in next PRs.