### PR TITLE
centering the logo and tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+<p align="center">
 <img src="https://raw.githubusercontent.com/google/grr/gh-pages/img/grr_logo_real_sm.png" />
 
+<p align="center">
 GRR Rapid Response is an incident response framework focused on remote live forensics.
 
 Links


### PR DESCRIPTION
The logo and the tagline weren't centered. I fixed this critical issue in the attached pull request.