### PR TITLE
Packer configs for unattended deployments

### DIFF
--- a/packer/docker.json
+++ b/packer/docker.json
@@ -1,0 +1,18 @@
+{
+
+  "provisioners": [
+    {
+        "type": "shell",
+        "scripts": [
+            "scripts/docker.sh"
+        ]
+    }
+],
+  "builders": [
+    {
+        "type": "docker",
+        "image": "ubuntu:trusty",
+        "commit": true
+    }
+  ]
+}

--- a/packer/http/preseed.cfg
+++ b/packer/http/preseed.cfg
@@ -1,0 +1,78 @@
+# Some inspiration:
+# * https://github.com/chrisroberts/vagrant-boxes/blob/master/definitions/precise-64/preseed.cfg
+# * https://github.com/cal/vagrant-ubuntu-precise-64/blob/master/preseed.cfg
+
+# English plx
+d-i debian-installer/language string en
+d-i debian-installer/locale string en_US.UTF-8
+d-i localechooser/preferred-locale string en_US.UTF-8
+d-i localechooser/supported-locales en_US.UTF-8
+
+# Including keyboards
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layout select USA
+d-i keyboard-configuration/variant select USA
+d-i keyboard-configuration/modelcode string pc105
+
+
+# Just roll with it
+d-i netcfg/get_hostname string this-host
+d-i netcfg/get_domain string this-host
+
+d-i time/zone string UTC
+d-i clock-setup/utc-auto boolean true
+d-i clock-setup/utc boolean true
+
+
+# Choices: Dialog, Readline, Gnome, Kde, Editor, Noninteractive
+d-i debconf debconf/frontend select Noninteractive
+
+d-i pkgsel/install-language-support boolean false
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+
+# Stuck between a rock and a HDD place
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-auto/choose_recipe select atomic
+
+d-i partman/confirm_write_new_label boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+
+# Write the changes to disks and configure LVM?
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-auto-lvm/guided_size string max
+
+# No proxy, plx
+d-i mirror/http/proxy string
+
+# Default user, change
+d-i passwd/user-fullname string grruser
+d-i passwd/username string grruser 
+d-i passwd/user-password password s3cur3password
+d-i passwd/user-password-again password s3cur3password
+d-i user-setup/encrypt-home boolean false
+d-i user-setup/allow-password-weak boolean true
+
+# No language support packages.
+d-i pkgsel/install-language-support boolean false
+
+# Individual additional packages to install
+d-i pkgsel/include string build-essential ssh
+
+#For the update
+d-i pkgsel/update-policy select none
+
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+d-i pkgsel/upgrade select safe-upgrade
+
+# Go grub, go!
+d-i grub-installer/only_debian boolean true
+
+d-i finish-install/reboot_in_progress note
+

--- a/packer/qemu.json
+++ b/packer/qemu.json
@@ -1,0 +1,55 @@
+{
+"provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/qemu.sh"
+      ],
+        "override": {
+            "qemu": {
+            "execute_command": "echo 's3cur3password' | sudo -S bash '{{ .Path }}'"
+            }
+        }
+    }
+  ],
+  "builders": [
+    {
+      "type": "qemu",
+      "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
+      "iso_checksum": "83aabd8dcf1e8f469f3c72fff2375195",
+      "iso_checksum_type": "md5",
+      "output_directory": "qemu/",
+      "shutdown_command": "echo 's3cur3password' | sudo -E -S shutdown -P now",
+      "disk_size": 40000,
+      "format": "qcow2",
+      "headless": false,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "http_port_min": 10082,
+      "http_port_max": 10089,
+      "ssh_host_port_min": 2222,
+      "ssh_host_port_max": 2229,
+      "ssh_username": "grruser",
+      "ssh_password": "s3cur3password",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "90m",
+      "vm_name": "qemu-ubuntu14-base",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_wait": "5s",
+      "boot_command":
+      [
+                "<esc><esc><enter><wait>",
+                "/install/vmlinuz ",
+                "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/preseed.cfg ",
+                "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+                "hostname={{.Name}} ",
+                "fb=false debconf/frontend=noninteractive ",
+                "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+                "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+                "initrd=/install/initrd.gz -- <enter>"
+      ]
+    }
+  ]
+}
+

--- a/packer/scripts/docker.sh
+++ b/packer/scripts/docker.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Docker image doesn't have some basics
+apt-get update
+apt-get install -y wget sudo
+
+wget --no-check-certificate https://raw.githubusercontent.com/google/grr/master/scripts/install_script_ubuntu.sh
+
+# We don't want to initialize because that has interactive prompts. Instead we craft config below.
+sed -i '/run_cmd_confirm grr_config_updater initialize/d' ./install_script_ubuntu.sh
+
+/bin/bash ./install_script_ubuntu.sh -y
+
+service grr-single-server stop
+
+# edit these to your liking
+echo "AdminUI.url: http://0.0.0.0:8000" >> /etc/grr/server.local.yaml
+echo "Monitoring.alert_email: grr-monitoring@example.com" >> /etc/grr/server.local.yaml
+echo "Monitoring.emergency_access_email: grr-emergency@example.com" >> /etc/grr/server.local.yaml
+echo "Client.control_urls: http://0.0.0.0:8080/control" >> /etc/grr/server.local.yaml
+echo "Logging.domain: example.com" >> /etc/grr/server.local.yaml
+echo "ClientBuilder.executables_path: /usr/share/grr/executables" >> /etc/grr/server.local.yaml
+echo "Client.name: grr-client" >> /etc/grr/server.local.yaml
+
+
+grr_config_updater generate_keys
+grr_config_updater repack_clients
+grr_config_updater update_user --password s3cur3password admin
+grr_config_updater load_memory_drivers
+
+#service grr-single-server start

--- a/packer/scripts/qemu.sh
+++ b/packer/scripts/qemu.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Make sure we have the basics
+apt-get update
+apt-get install -y wget sudo
+
+wget --no-check-certificate https://raw.githubusercontent.com/google/grr/master/scripts/install_script_ubuntu.sh
+
+
+# We don't want to initialize because that has interactive prompts. Instead we craft config below.
+sed -i '/run_cmd_confirm grr_config_updater initialize/d' ./install_script_ubuntu.sh
+
+/bin/bash ./install_script_ubuntu.sh -y
+
+service grr-single-server stop
+
+# edit these to your liking
+echo "AdminUI.url: http://0.0.0.0:8000" >> /etc/grr/server.local.yaml
+echo "Monitoring.alert_email: grr-monitoring@example.com" >> /etc/grr/server.local.yaml
+echo "Monitoring.emergency_access_email: grr-emergency@example.com" >> /etc/grr/server.local.yaml
+echo "Client.control_urls: http://0.0.0.0:8080/control" >> /etc/grr/server.local.yaml
+echo "Logging.domain: example.com" >> /etc/grr/server.local.yaml
+echo "ClientBuilder.executables_path: /usr/share/grr/executables" >> /etc/grr/server.local.yaml
+echo "Client.name: grr-client" >> /etc/grr/server.local.yaml
+
+grr_config_updater generate_keys
+grr_config_updater repack_clients
+grr_config_updater update_user --password s3cur3password admin
+grr_config_updater load_memory_drivers
+
+service grr-single-server start


### PR DESCRIPTION
This Pull Request is to start a discussion about unattended deployments of GRR. After my post on the mailing list https://groups.google.com/forum/#!topic/grr-dev/D8GKX37coME I figured I could help tackle this task.

Using ![packer.io](http://packer.io), it is possible to build GRR into aws, digitalocean, docker, qemu, etc...

I'm working on a management framework project for GRR that utilizes this technique. I push the completed GRR image to Proxmox and allocate the resources using its api.

The docker builder doesn't quite work yet. It installs GRR all the way though. I'm having an issue with the ubuntu trusty docker image and upstart: `ERROR: version of /sbin/initctl too old`

The scripts/docker.sh & qemu.sh should be edited to match your server.local.yaml. This is just a bash script I made quickly.

To build qcow2 image:
```
packer build qemu.json
```
To build docker:
```
packer build docker.json
```

It may not be perfect at the moment, but it does _work_. This can be a stepping off point to dockerize GRR or deploy to cloud services.

Sidenote: Currently a bug exists with Packer and Docker that has been addressed and a user-made fix has been created (https://github.com/mitchellh/packer/issues/1752#issuecomment-74415289)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/grr/124)
<!-- Reviewable:end -->
