### PR TITLE
Removed unecessary forced regex

### DIFF
--- a/lib/aff4_objects/filestore.py
+++ b/lib/aff4_objects/filestore.py
@@ -200,7 +200,7 @@ class FileStoreImage(aff4.VFSBlobImage):
       index.
     """
     # Make the regular expression.
-    regex = ["index:target:.*%s.*" % target_regex.lower()]
+    regex = ["index:target:%s" % target_regex.lower()]
     if isinstance(limit, (tuple, list)):
       start, length = limit  # pylint: disable=unpacking-non-sequence
 


### PR DESCRIPTION
This forced modification of the regex causes a brutal performance hit (7s queries vs 0.3s queries in the tested example).  It would be better to send the regex as desired in any calls to this.  This appears to be what it is doing in filestore_stats.py, but I'm not clear on all of the other places where this is getting called.  This passes unit tests and I am going to begin testing it in a live test environment, but any heads up on other places where this change needs to be accounted for would be appreciated.