### PR TITLE
RHEL Repack fix

### DIFF
--- a/lib/build.py
+++ b/lib/build.py
@@ -786,7 +786,6 @@ class CentosClientDeployer(LinuxClientDeployer):
           rpmbuild_binary,
           "--define", "_topdir " + rpm_root_dir,
           "--target", client_arch,
-          "--buildroot", rpm_build_dir,
           "-bb", spec_filename]
       try:
         subprocess.check_output(command, stderr=subprocess.STDOUT)


### PR DESCRIPTION
This line breaks rpm repacking on RHEL.  If this is necessary for proper behavior on other server platforms I will try to work out specifically why there is a difference in behavior.