### PR TITLE
Removed unnecessary regex escaping

### DIFF
--- a/gui/api_plugins/stats.py
+++ b/gui/api_plugins/stats.py
@@ -75,7 +75,7 @@ class ApiStatsStoreMetricRenderer(api_call_renderers.ApiCallRenderer):
 
     data = stats_store.MultiReadStats(
         process_ids=filtered_ids,
-        predicate_regex=re.escape(utils.SmartStr(args.metric_name)),
+        predicate_regex=utils.SmartStr(args.metric_name),
         timestamp=(start_time, end_time))
 
     if not data:


### PR DESCRIPTION
This may not be the best way to solve this, but the normal use only involves _ and it gets escaped to \\_ so the datastore is unable to optimize against using a regex since ultimately the whole query becomes the full attribute and not a regex at all.  This changes the queries for even a 1hr window from multiple 5+ second queries all queries being sub 1s.