### PR TITLE
RPM Build fixes

### DIFF
--- a/config/centos/grr.spec.in
+++ b/config/centos/grr.spec.in
@@ -19,6 +19,7 @@ URL: https://github.com/google/grr
 # Do nothing here.
 
 %install
+cp -R \%{_builddir}/* \%{buildroot}
 
 %clean
 

--- a/lib/build.py
+++ b/lib/build.py
@@ -725,6 +725,9 @@ class CentosClientDeployer(LinuxClientDeployer):
       rpm_build_dir = os.path.join(rpm_root_dir, "BUILD")
       self.EnsureDirExists(rpm_build_dir)
 
+      rpm_buildroot_dir = os.path.join(rpm_root_dir, "BUILDROOT")
+      self.EnsureDirExists(rpm_buildroot_dir)
+
       rpm_rpms_dir = os.path.join(rpm_root_dir, "RPMS")
       self.EnsureDirExists(rpm_rpms_dir)
 
@@ -788,7 +791,7 @@ class CentosClientDeployer(LinuxClientDeployer):
           rpmbuild_binary,
           "--define", "_topdir " + rpm_root_dir,
           "--target", client_arch,
-          "--buildroot", rpm_build_dir,
+          "--buildroot", rpm_buildroot_dir,
           "-bb", spec_filename]
       try:
         subprocess.check_output(command, stderr=subprocess.STDOUT)


### PR DESCRIPTION
This should fix the build issues.  The expectation is that %install empties BUILDROOT and then copies BUILD into BUILDROOT (typically using make install).  Because these were being used as the same dir RHEL blows everything away and then fails to pack.  This change should assemble the client in BUILD as normal and then declare BUILDROOT as the target and then the cp command replaces what make install would normally do.