### PR TITLE
Switched from LONGBLOB to MEDIUMBLOB for value storage

### DIFF
--- a/lib/data_stores/mysql_advanced_data_store.py
+++ b/lib/data_stores/mysql_advanced_data_store.py
@@ -575,7 +575,7 @@ class MySQLAdvancedDataStore(data_store.DataStore):
       subject_hash BINARY(16) NOT NULL,
       attribute_hash BINARY(16) NOT NULL,
       timestamp BIGINT UNSIGNED DEFAULT NULL,
-      value LONGBLOB NULL,
+      value MEDIUMBLOB NULL,
       KEY `master` (`subject_hash`,`attribute_hash`,`timestamp`),
       KEY `attribute` (`attribute_hash`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8


### PR DESCRIPTION
This works in a test environment so if GRR isn't going to try to store larger things in the value field this is a slightly better schema.