### PR TITLE
ACL Token expiry

### DIFF
--- a/config/server.py
+++ b/config/server.py
@@ -101,6 +101,9 @@ config_lib.DEFINE_list("Cron.enabled_system_jobs", [],
 config_lib.DEFINE_integer("ACL.approvers_required", 2,
                           "The number of approvers required for access.")
 
+config_lib.DEFINE_integer("ACL.token_expiry", 480,
+                          "The duration in minutes of a valid approval token.")
+
 config_lib.DEFINE_string("Frontend.bind_address", "::",
                          "The ip address to bind.")
 

--- a/config/server.py
+++ b/config/server.py
@@ -101,7 +101,7 @@ config_lib.DEFINE_list("Cron.enabled_system_jobs", [],
 config_lib.DEFINE_integer("ACL.approvers_required", 2,
                           "The number of approvers required for access.")
 
-config_lib.DEFINE_integer("ACL.token_expiry", 480,
+config_lib.DEFINE_integer("ACL.token_expiry", 10080,
                           "The duration in minutes of a valid approval token.")
 
 config_lib.DEFINE_string("Frontend.bind_address", "::",

--- a/config/server.py
+++ b/config/server.py
@@ -101,8 +101,8 @@ config_lib.DEFINE_list("Cron.enabled_system_jobs", [],
 config_lib.DEFINE_integer("ACL.approvers_required", 2,
                           "The number of approvers required for access.")
 
-config_lib.DEFINE_integer("ACL.token_expiry", 10080,
-                          "The duration in minutes of a valid approval token.")
+config_lib.DEFINE_integer("ACL.token_expiry", 604800,
+                          "The duration in seconds of a valid approval token. Default of one week.")
 
 config_lib.DEFINE_string("Frontend.bind_address", "::",
                          "The ip address to bind.")

--- a/lib/access_control_test.py
+++ b/lib/access_control_test.py
@@ -148,18 +148,15 @@ class AccessControlTest(test_lib.GRRBaseTest):
       # This should work now.
       aff4.FACTORY.Open(urn, mode="rw", token=token)
 
-    # 3 weeks later.
-    with test_lib.FakeTime(100.0 + 3 * 7 * 24 * 60 * 60):
+    token_expiry = config_lib.CONFIG["ACL.token_expiry"]
+
+    # close to expiry but should still work
+    with test_lib.FakeTime(100.0 + token_expiry - 100.0):
       # This should still work.
       aff4.FACTORY.Open(urn, mode="rw", token=token)
 
-    # Getting close.
-    with test_lib.FakeTime(100.0 + 4 * 7 * 24 * 60 * 60 - 100.0):
-      # This should still work.
-      aff4.FACTORY.Open(urn, mode="rw", token=token)
-
-    # Over 4 weeks now.
-    with test_lib.FakeTime(100.0 + 4 * 7 * 24 * 60 * 60 + 100.0):
+    # past expiry that should fail
+    with test_lib.FakeTime(100.0 + token_expiry + 100.0):
       self.assertRaises(access_control.UnauthorizedAccess,
                         aff4.FACTORY.Open, urn, None, "rw", token)
 

--- a/lib/aff4_objects/security.py
+++ b/lib/aff4_objects/security.py
@@ -155,7 +155,7 @@ class ApprovalWithApproversAndReason(Approval):
     LIFETIME = aff4.Attribute(
         "aff4:approval/lifetime", rdfvalue.RDFInteger,
         "The number of seconds an approval is valid for.",
-        default=7 * 24 * 60 * 60) # one week in seconds
+        default=0) 
     BREAK_GLASS = aff4.Attribute(
         "aff4:approval/breakglass", rdfvalue.RDFDatetime,
         "The date when this break glass approval will expire.")
@@ -193,8 +193,7 @@ class ApprovalWithApproversAndReason(Approval):
       return True
 
     # Check that there are enough approvers.
-    lifetime = config_lib.CONFIG["ACL.token_expiry"] 
-    lifetime *= 60  # convert to seconds
+    lifetime =  self.Get(self.Schema.LIFETIME) or config_lib.CONFIG["ACL.token_expiry"] 
 
     approvers = set()
     for approver in self.GetValuesForAttribute(self.Schema.APPROVER):

--- a/lib/aff4_objects/security.py
+++ b/lib/aff4_objects/security.py
@@ -4,8 +4,6 @@
 
 import email
 import urllib
-import sys
-import traceback
 
 from grr.lib import access_control
 from grr.lib import aff4

--- a/lib/aff4_objects/security.py
+++ b/lib/aff4_objects/security.py
@@ -193,12 +193,8 @@ class ApprovalWithApproversAndReason(Approval):
       return True
 
     # Check that there are enough approvers.
-    lifetime = self.Get(self.Schema.LIFETIME) 
-    try: # override if configured
-      lifetime = config_lib.CONFIG["ACL.token_expiry"] 
-      lifetime *= 60  # convert to seconds
-    except Exception, err:
-      pass
+    lifetime = config_lib.CONFIG["ACL.token_expiry"] 
+    lifetime *= 60  # convert to seconds
 
     approvers = set()
     for approver in self.GetValuesForAttribute(self.Schema.APPROVER):


### PR DESCRIPTION
config_lib is not instantiated except for constants when LIFETIME is defined.  So, ACL.token_expiry cannot override LIFETIME and thus LIFETIME is not used in CheckAccess().