### PR TITLE
Lowered severity of PyInstaller import error

### DIFF
--- a/lib/build.py
+++ b/lib/build.py
@@ -22,7 +22,7 @@ import distorm3
 try:
   from PyInstaller import main as PyInstallerMain
 except ImportError:
-  logging.error("PyInstaller missing")
+  logging.warn("PyInstaller missing")
 
 from grr.lib import config_lib
 from grr.lib import rdfvalue

--- a/lib/build.py
+++ b/lib/build.py
@@ -22,7 +22,10 @@ import distorm3
 try:
   from PyInstaller import main as PyInstallerMain
 except ImportError:
-  logging.warn("PyInstaller missing")
+  # We ignore this failure since most people running the code don't build their
+  # own clients and printing an error message causes confusion.  Those building
+  # their own clients will need PyInstaller installed.
+  pass
 
 from grr.lib import config_lib
 from grr.lib import rdfvalue


### PR DESCRIPTION
This isn't really an error for the majority of cases where build.py is getting loaded so lowering to a warning to clear up logs.  New users have also reported feelings of confusion and doubt when encountering this error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/grr/172)
<!-- Reviewable:end -->
