### PR TITLE
Extended flow durations to 1d

### DIFF
--- a/lib/flows/cron/data_retention.py
+++ b/lib/flows/cron/data_retention.py
@@ -15,7 +15,7 @@ class CleanHunts(cronjobs.SystemCronFlow):
   """Cleaner that deletes old hunts."""
 
   frequency = rdfvalue.Duration("7d")
-  lifetime = rdfvalue.Duration("6h")
+  lifetime = rdfvalue.Duration("1d")
 
   @flow.StateHandler()
   def Start(self):
@@ -50,7 +50,7 @@ class CleanCronJobs(cronjobs.SystemCronFlow):
   """Cleaner that deletes old finished cron flows."""
 
   frequency = rdfvalue.Duration("7d")
-  lifetime = rdfvalue.Duration("6h")
+  lifetime = rdfvalue.Duration("1d")
 
   @flow.StateHandler()
   def Start(self):


### PR DESCRIPTION
These hunts can take longer than 6hrs to successfully run if there is a larger amount of data to get through.  I have had instances of both complete the deletes, but still report timeout errors.  1d seems like a reasonable limit for a weekly cron.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/grr/214)
<!-- Reviewable:end -->
