### PR TITLE
Interrogate fix

### DIFF
--- a/lib/client_index.py
+++ b/lib/client_index.py
@@ -248,7 +248,8 @@ def GetClientURNsForHostnames(hostnames, token=None):
   """
 
   index = aff4.FACTORY.Create(
-      MAIN_INDEX, aff4_type="ClientIndex", mode="rw", token=token)
+      MAIN_INDEX, aff4_type="ClientIndex", mode="rw", object_exists=True,
+      token=token)
 
   keywords = set()
   for hostname in hostnames:
@@ -283,7 +284,8 @@ def BulkLabel(label, hostnames, token, client_index=None):
   """
   if client_index is None:
     client_index = aff4.FACTORY.Create(
-        MAIN_INDEX, aff4_type="ClientIndex", mode="rw", token=token)
+        MAIN_INDEX, aff4_type="ClientIndex", mode="rw", object_exists=True,
+        token=token)
 
   fqdns = set()
   for hostname in hostnames:

--- a/lib/flows/general/ca_enroller.py
+++ b/lib/flows/general/ca_enroller.py
@@ -75,6 +75,7 @@ class CAEnroler(flow.GRRFlow):
 
     index = aff4.FACTORY.Create(client_index.MAIN_INDEX,
                                 aff4_type="ClientIndex",
+                                object_exists=True,
                                 mode="rw", token=self.token)
     index.AddClient(client)
     client.Close(sync=True)

--- a/lib/flows/general/discovery.py
+++ b/lib/flows/general/discovery.py
@@ -127,6 +127,7 @@ class Interrogate(flow.GRRFlow):
       aff4.FACTORY.Create(client_index.MAIN_INDEX,
                           aff4_type="ClientIndex",
                           mode="rw",
+                          object_exists=True,
                           token=self.token).AddClient(self.client)
 
     else:
@@ -177,6 +178,7 @@ class Interrogate(flow.GRRFlow):
     aff4.FACTORY.Create(client_index.MAIN_INDEX,
                         aff4_type="ClientIndex",
                         mode="rw",
+                        object_exists=True,
                         token=self.token).AddClient(self.client)
 
   @flow.StateHandler()
@@ -311,4 +313,5 @@ class Interrogate(flow.GRRFlow):
     aff4.FACTORY.Create(client_index.MAIN_INDEX,
                         aff4_type="ClientIndex",
                         mode="rw",
+                        object_exists=True,
                         token=self.token).AddClient(self.client)


### PR DESCRIPTION
I left the Creates in the UI alone since they shouldn't ever be encountered at a rate that causes problems and it should ensure that the client index does get added to the root index so that nothing is fundamentally altered in how everything is getting stored.

I will be testing this soon against MySQLAdvanced with a much larger connection pool to ensure this solves the interrogate hunt performance issues.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/grr/220)
<!-- Reviewable:end -->
