### PR TITLE
Add case to GetDistro() for CentOS linux.

### DIFF
--- a/lib/distro_entry.py
+++ b/lib/distro_entry.py
@@ -27,9 +27,7 @@ def GetDistro():
     distribution = platform.linux_distribution()[0].lower()
     if distribution in ["ubuntu", "debian"]:
       return "debian"
-    if distribution in ["red hat enterprise linux server"]:
-      return "redhat"
-    if distribution in ["centos linux"]:
+    if distribution in ["red hat enterprise linux server", "centos linux"]:
       return "redhat"
   raise RuntimeError("Missing distro specific config. Please update "
                      "distro_entry.py.")

--- a/lib/distro_entry.py
+++ b/lib/distro_entry.py
@@ -29,6 +29,8 @@ def GetDistro():
       return "debian"
     if distribution in ["red hat enterprise linux server"]:
       return "redhat"
+    if distribution in ["centos linux"]:
+      return "redhat"
   raise RuntimeError("Missing distro specific config. Please update "
                      "distro_entry.py.")
 


### PR DESCRIPTION
Operating system detection for setting up server.yml non functional on CentOS to spite binary compatibility.  Added a case for this to GetDistro().