### PR TITLE
Set artifacts to 20160617 release for 3102 branch.

### DIFF
--- a/grr/artifacts/makefile.py
+++ b/grr/artifacts/makefile.py
@@ -10,7 +10,7 @@ import zipfile
 
 def main():
   data = urllib2.urlopen(
-      "https://github.com/ForensicArtifacts/artifacts/archive/20160713.zip").read(
+      "https://github.com/ForensicArtifacts/artifacts/archive/20160617.zip").read(
       )
 
   zip_obj = zipfile.ZipFile(StringIO.StringIO(data))


### PR DESCRIPTION
- The 3102 server was released before a large artifact rename change so the
  server needs to use the older version.