### PR TITLE
worker: Drop privileges if necessary

### DIFF
--- a/grr/worker/worker.py
+++ b/grr/worker/worker.py
@@ -27,6 +27,7 @@ def main(unused_argv):
   server_startup.Init()
   token = access_control.ACLToken(username="GRRWorker").SetUID()
   worker_obj = worker.GRRWorker(token=token)
+  server_startup.DropPrivileges()
   worker_obj.Run()
 
 


### PR DESCRIPTION
When using the SQLite data store with Server.username configured,
workers running as root would create database files that could not be
manipulated through the GUI or API, making the system unusable.