### PR TITLE
linux client interrogate fixes

### DIFF
--- a/grr/client/client_actions/linux/linux.py
+++ b/grr/client/client_actions/linux/linux.py
@@ -169,7 +169,13 @@ class GetInstallDate(actions.ActionPlugin):
   out_rdfvalues = [rdf_protodict.DataBlob]
 
   def Run(self, unused_args):
-    self.SendReply(integer=int(os.stat("/lost+found").st_ctime))
+    ctime = 0
+    for path in ("/lost+found", "/"):
+      try:
+        ctime = os.stat(path).st_ctime
+      except OSError:
+        continue
+    self.SendReply(integer=int(ctime))
 
 
 class UtmpStruct(utils.Struct):


### PR DESCRIPTION
while playing with the RPM client package on CentOS 7 and SuSE Enterprise Linux machines, I noticed that the interrogation feature failed at several stages. None of the /etc/*release files exists on SuSE and /lost+found does not exist when the rootFS is either XFS or BTRFS.

Both patches are untested.