### PR TITLE
Add PATH var tweak to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,10 @@ pip install --find-links=/wheelhouse /sdists/core/*.tar.gz && \
 pip install --find-links=/wheelhouse /sdists/server/*.tar.gz && \
 pip install --find-links=/wheelhouse grr_response_templates
 
+# Add bin path to PATH so it can run commands like grr_config_updater or grr_console
+RUN export PATH=$PATH:/usr/share/grr-server/bin/
+RUN echo 'export PATH=$PATH:/usr/share/grr-server/bin/' >> /root/.profile
+
 COPY scripts/docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Closes #501 
Issue is explained at the issue.

To justify why I did it like this:

- PATH precedence means if things get mucked up it can use, for example, pip in the bin directory but it won't select it by default unless it can't find it in the existing PATH
- Symlinking is a pain for this many tools and I don't know for sure which the maintainers would want accessible and which wouldn't
- It works in a default `sh` which is what the Dockerfile is run under

