### PR TITLE
Bugfix frontend service

### DIFF
--- a/grr/gui/admin_ui.py
+++ b/grr/gui/admin_ui.py
@@ -52,8 +52,8 @@ def main(_):
     # Address looks like an IPv4 address.
     ThreadedServer.address_family = socket.AF_INET
 
-  max_port = config_lib.CONFIG.Get("AdminUI.port_max",
-                                   config_lib.CONFIG["AdminUI.port"])
+  max_port = (config_lib.CONFIG["AdminUI.port_max"] +
+              config_lib.CONFIG["AdminUI.port"])
 
   for port in range(config_lib.CONFIG["AdminUI.port"], max_port + 1):
     # Make a simple reference implementation WSGI server

--- a/grr/tools/frontend.py
+++ b/grr/tools/frontend.py
@@ -281,8 +281,8 @@ class GRRHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
 
 def CreateServer(frontend=None):
   """Start frontend http server."""
-  max_port = config_lib.CONFIG.Get("Frontend.port_max",
-                                   config_lib.CONFIG["Frontend.bind_port"])
+  max_port = config_lib.CONFIG.Get("Frontend.port_max") +
+                                   config_lib.CONFIG["Frontend.bind_port"]
 
   for port in range(config_lib.CONFIG["Frontend.bind_port"], max_port + 1):
 

--- a/grr/tools/frontend.py
+++ b/grr/tools/frontend.py
@@ -281,8 +281,8 @@ class GRRHTTPServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
 
 def CreateServer(frontend=None):
   """Start frontend http server."""
-  max_port = config_lib.CONFIG.Get("Frontend.port_max") +
-                                   config_lib.CONFIG["Frontend.bind_port"]
+  max_port = (config_lib.CONFIG["Frontend.port_max"] +
+              config_lib.CONFIG["Frontend.bind_port"])
 
   for port in range(config_lib.CONFIG["Frontend.bind_port"], max_port + 1):
 


### PR DESCRIPTION
Found this bug when creating front end servers:
Line 15 is how GRR currently sets `max_port`, Line 16 is how I want to set it
```
In [15]: config_lib.CONFIG.Get("Frontend.port_max", config_lib.CONFIG["Frontend.bind_port"])
Out[15]: 4L

In [16]: config_lib.CONFIG["Frontend.port_max"] + config_lib.CONFIG["Frontend.bind_port"]
Out[16]: 8084L

In [17]: config_lib.CONFIG["Frontend.port_max"]
Out[17]: 4L

In [18]: config_lib.CONFIG["Frontend.bind_port"]
Out[18]: 8080L
```
