### PR TITLE
Redact Bigquery Service Account JSON

### DIFF
--- a/grr/server/grr_response_server/gui/api_plugins/config.py
+++ b/grr/server/grr_response_server/gui/api_plugins/config.py
@@ -25,7 +25,8 @@ from grr_response_server.gui import api_call_handler_utils
 # when new sensitive option is added, but these lists are not updated.
 REDACTED_OPTIONS = [
     "AdminUI.django_secret_key", "AdminUI.csrf_secret_key",
-    "Mysql.database_password", "Worker.smtp_password"
+    "BigQuery.service_acct_json", "Mysql.database_password", 
+    "Worker.smtp_password"
 ]
 REDACTED_SECTIONS = ["PrivateKeys", "Users"]
 


### PR DESCRIPTION
I noticed this field wasn't redacted on the Settings page in the Admin UI. This JSON will contain a private key, so I believe it shouldn't be shown here, in the same fashion other private keys and passwords are not shown.