### PR TITLE
Additional whitelist command

### DIFF
--- a/grr/client/grr_response_client/client_utils_common.py
+++ b/grr/client/grr_response_client/client_utils_common.py
@@ -148,6 +148,7 @@ def IsExecutionWhitelisted(cmd, args):
         ("arp.exe", ["-a"]),
         ("driverquery.exe", ["/v"]),
         ("ipconfig.exe", ["/all"]),
+        ("netsh.exe", ["advfirewall"], ["firewall"], ["show"], ["rule"], ["name=all"]),
         ("tasklist.exe", ["/SVC"]),
         ("tasklist.exe", ["/v"]),
     ]


### PR DESCRIPTION
Add whitelist for Windows netsh.exe <…> command, to be able to fetch the windows firewall
configuration.