### PR TITLE
Exec wrapped GRR python scripts instead of launching a subprocess

### DIFF
--- a/grr/core/scripts/debian_launcher
+++ b/grr/core/scripts/debian_launcher
@@ -32,4 +32,4 @@ fi
 # $@ is expanded specially and should be quoted:
 # http://www.gnu.org/software/bash/manual/bash.html#Special-Parameters
 # GRR_EXTRA_ARGS is an array of argv so it needs to be quoted too.
-"${GRR_PREFIX}/bin/${NAME}" "${GRR_EXTRA_ARGS[@]}" "${@}"
+exec "${GRR_PREFIX}/bin/${NAME}" "${GRR_EXTRA_ARGS[@]}" "${@}"

--- a/grr/core/scripts/debian_launcher_no_extra_args
+++ b/grr/core/scripts/debian_launcher_no_extra_args
@@ -31,4 +31,4 @@ fi
 # Run the script.
 # $@ is expanded specially and should be quoted:
 # http://www.gnu.org/software/bash/manual/bash.html#Special-Parameters
-"${GRR_PREFIX}/bin/${NAME}" "${@}"
+exec "${GRR_PREFIX}/bin/${NAME}" "${@}"


### PR DESCRIPTION
Avoid a long-running unnecessary shell process lurking around.
Improves signal forwarding from systemd to actual python process.