### PR TITLE
Make grr-server components a part of main grr-server.service unit

### DIFF
--- a/debian/grr-server.service
+++ b/debian/grr-server.service
@@ -3,15 +3,16 @@
 
 [Unit]
 Description=GRR Service
-After=syslog.target network.target
+After=network.target
+After=syslog.target
 Documentation=https://github.com/google/grr
 
 [Service]
 Type=oneshot
+User=nobody
+Group=nogroup
+ExecStart=/bin/true
 RemainAfterExit=yes
-ExecReload=/bin/systemctl --no-block reload grr-server@admin_ui.service grr-server@frontend.service grr-server@worker.service grr-server@worker2.service
-ExecStart=/bin/systemctl --no-block start grr-server@admin_ui.service grr-server@frontend.service grr-server@worker.service grr-server@worker2.service
-ExecStop=/bin/systemctl --no-block stop grr-server@admin_ui.service grr-server@frontend.service grr-server@worker.service grr-server@worker2.service
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/grr-server@.service
+++ b/debian/grr-server@.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=GRR %I
+After=grr-server.service
 PartOf=grr-server.service
 ReloadPropagatedFrom=grr-server.service
-After=syslog.target network.target
 Documentation=https://github.com/google/grr
 
 [Service]
@@ -15,4 +15,4 @@ ExecStartPre=/bin/mkdir -p /var/run/grr/tmp/%i
 ExecStart=/usr/bin/grr_server --component %i --disallow_missing_config_definitions -p StatsStore.process_id=%i_%m
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=grr-server.service


### PR DESCRIPTION
This makes the instantiation of components more explicit.

Instead of implicitly launching components via systemctl they
can be created as symlinks to or copies of the template on disk.