### PR TITLE
Make use of private tmp instead of custom tmp location

### DIFF
--- a/debian/grr-server@.service
+++ b/debian/grr-server@.service
@@ -10,8 +10,8 @@ Type=simple
 PrivateTmp=true
 Restart=on-failure
 LimitNOFILE=65536
-Environment="MPLCONFIGDIR=/var/run/grr/tmp/%i" "PYTHON_EGG_CACHE=/var/run/grr/tmp/%i"
-ExecStartPre=/bin/mkdir -p /var/run/grr/tmp/%i
+Environment="MPLCONFIGDIR=/tmp/grr_%i" "PYTHON_EGG_CACHE=/tmp/grr_%i"
+ExecStartPre=/bin/mkdir -p /tmp/grr_%i
 ExecStart=/usr/bin/grr_server --component %i --disallow_missing_config_definitions -p StatsStore.process_id=%i_%m
 
 [Install]


### PR DESCRIPTION
Since systemd already creates a private tmp this should be used.