### PR TITLE
Discover Python 3 syntax errors and undefined names in --exit-zero mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -312,6 +312,13 @@ matrix:
 
           travis/deploy_to_gcs.sh
 
+    # Discover Python 3 syntax errors and undefined names in --exit-zero mode
+    - python: 3.7
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      install: pip install flake8
+      script: flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics
+
+
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
With [one year left](http://pythonclock.org) until the end of life of Python 2, let's see where there are Python 3 compatibility issues.

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree