### PR TITLE
Fix mysql database fail to start due to permissions issues.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,6 @@ EXPOSE 8080
 # Directories used by GRR at runtime, which can be mounted from the host's
 # filesystem. Note that volumes can be mounted even if they do not appear in
 # this list.
-VOLUME ["/usr/share/grr-server/install_data/etc"]
+VOLUME ["/usr/share/grr-server/install_data/etc", "/var/lib/mysql"]
 
 CMD ["grr"]


### PR DESCRIPTION
GRR container fail to start because of a MySQL permissions error on '/var/lib/mysql' (the MySQL fail to start).
mounting the path as a volume fix's the problem.

inspired by https://github.com/geerlingguy/drupal-vm/issues/1497