### PR TITLE
[IAP] Add IAP Web Auth Support

### DIFF
--- a/grr/core/grr_response_core/config/gui.py
+++ b/grr/core/grr_response_core/config/gui.py
@@ -142,11 +142,11 @@ config_lib.DEFINE_bool(
 
 # Configuration requirements for Cloud IAP Setup
 config_lib.DEFINE_string(
-    "AdminUI.cloud_project_id", None,
+    "AdminUI.google_cloud_project_id", None,
     "Cloud Project ID for IAP. This must be set if the IAPWebAuthManager is used."
 )
 
 config_lib.DEFINE_string(
-    "AdminUI.cloud_backend_service_id", None,
+    "AdminUI.google_cloud_backend_service_id", None,
     "GCP Cloud Backend Service ID for IAP. This must be set if the IAPWebAuthManager is used."
 )

--- a/grr/core/grr_response_core/config/gui.py
+++ b/grr/core/grr_response_core/config/gui.py
@@ -139,3 +139,14 @@ config_lib.DEFINE_bool(
     "When running in headless mode, AdminUI ignores checks for JS/CSS compiled "
     "bundles being present. AdminUI.headless=True should be used to run "
     "the AdminUI as an API endpoint only.")
+
+# Configuration requirements for Cloud IAP Setup
+config_lib.DEFINE_string(
+    "AdminUI.cloud_project_id", None,
+    "Cloud Project ID for IAP. This must be set if the IAPWebAuthManager is used."
+)
+
+config_lib.DEFINE_string(
+    "AdminUI.cloud_backend_service_id", None,
+    "GCP Cloud Backend Service ID for IAP. This must be set if the IAPWebAuthManager is used."
+)

--- a/grr/server/grr_response_server/gui/validate_iap.py
+++ b/grr/server/grr_response_server/gui/validate_iap.py
@@ -1,17 +1,3 @@
-# Copyright 2016 Google Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """Sample showing how to validate the Identity-Aware Proxy (IAP) JWT.
 
 This code should be used by applications in Google Compute Engine-based
@@ -22,7 +8,6 @@ of assurance that a request was authorized by IAP.
 For applications running in the App Engine standard environment, use
 App Engine's Users API instead.
 """
-# [START iap_validate_jwt]
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
@@ -94,5 +79,3 @@ def GetIapKey(key_id):
         if not key:
             raise Exception('Key {!r} not found'.format(key_id))
     return key
-
-# [END iap_validate_jwt]

--- a/grr/server/grr_response_server/gui/validate_iap.py
+++ b/grr/server/grr_response_server/gui/validate_iap.py
@@ -1,0 +1,93 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample showing how to validate the Identity-Aware Proxy (IAP) JWT.
+
+This code should be used by applications in Google Compute Engine-based
+environments (such as Google App Engine flexible environment, Google
+Compute Engine, or Google Container Engine) to provide an extra layer
+of assurance that a request was authorized by IAP.
+
+For applications running in the App Engine standard environment, use
+App Engine's Users API instead.
+"""
+# [START iap_validate_jwt]
+import jwt
+import requests
+
+def ValidateIapJwtFromComputeEngine(iap_jwt, cloud_project_number,
+                                         backend_service_id):
+    """Validate an IAP JWT for your (Compute|Container) Engine service.
+
+    Args:
+      iap_jwt: The contents of the X-Goog-IAP-JWT-Assertion header.
+      cloud_project_number: The project *number* for your Google Cloud project.
+          This is returned by 'gcloud projects describe $PROJECT_ID', or
+          in the Project Info card in Cloud Console.
+      backend_service_id: The ID of the backend service used to access the
+          application. See
+          https://cloud.google.com/iap/docs/signed-headers-howto
+          for details on how to get this value.
+
+    Returns:
+      (user_id, user_email, error_str).
+    """
+    expected_audience = '/projects/{}/global/backendServices/{}'.format(
+        cloud_project_number, backend_service_id)
+    return ValidateIapJwt(iap_jwt, expected_audience)
+
+
+def ValidateIapJwt(iap_jwt, expected_audience):
+    try:
+        key_id = jwt.get_unverified_header(iap_jwt).get('kid')
+        if not key_id:
+            return (None, None, '**ERROR: no key ID**')
+        key = GetIapKey(key_id)
+        decoded_jwt = jwt.decode(
+            iap_jwt, key,
+            algorithms=['ES256'],
+            audience=expected_audience)
+        return (decoded_jwt['sub'], decoded_jwt['email'], '')
+    except (jwt.exceptions.InvalidTokenError,
+            requests.exceptions.RequestException) as e:
+        return (None, None, '**ERROR: JWT validation error {}**'.format(e))
+
+
+def GetIapKey(key_id):
+    """Retrieves a public key from the list published by Identity-Aware Proxy,
+    re-fetching the key file if necessary.
+    """
+    key_cache = GetIapKey.key_cache
+    key = key_cache.get(key_id)
+    if not key:
+        # Re-fetch the key file.
+        resp = requests.get(
+            'https://www.gstatic.com/iap/verify/public_key')
+        if resp.status_code != 200:
+            raise Exception(
+                'Unable to fetch IAP keys: {} / {} / {}'.format(
+                    resp.status_code, resp.headers, resp.text))
+        key_cache = resp.json()
+        GetIapKey.key_cache = key_cache
+        key = key_cache.get(key_id)
+        if not key:
+            raise Exception('Key {!r} not found'.format(key_id))
+    return key
+
+
+# Used to cache the Identity-Aware Proxy public keys.  This code only
+# refetches the file when a JWT is signed with a key not present in
+# this cache.
+GetIapKey.key_cache = {}
+# [END iap_validate_jwt]

--- a/grr/server/setup.py
+++ b/grr/server/setup.py
@@ -171,6 +171,7 @@ setup_args = dict(
         "python-crontab==2.0.1",
         "python-debian==0.1.31",
         "Werkzeug==0.11.3",
+        "pyjwt==1.7.1",
     ],
     extras_require={
         # This is an optional component. Install to get MySQL data


### PR DESCRIPTION
This PR Adds Authentication support from Google's IAP service. The extension pulls the x-google-iap-jwt-assertion header from IAP and generates a new user for that header via the 'sub' claim. Authorization is delegated via IAP.

