### PR TITLE
Implement discussed changes in #735.

### DIFF
--- a/grr/client_builder/grr_response_client_builder/build.py
+++ b/grr/client_builder/grr_response_client_builder/build.py
@@ -178,7 +178,7 @@ class ClientBuilder(BuilderBase):
     PyInstallerMain.run(pyi_args=[utils.SmartStr(x) for x in args])
 
     # Clear out some crud that pyinstaller includes.
-    for path in ["tcl", "tk", "pytz"]:
+    for path in ["tcl", "tk", "pytz", "certs"]:
       dir_path = os.path.join(self.output_dir, path)
       try:
         shutil.rmtree(dir_path)

--- a/grr/core/grr_response_core/config/client.py
+++ b/grr/core/grr_response_core/config/client.py
@@ -159,7 +159,24 @@ config_lib.DEFINE_semantic_value(
 config_lib.DEFINE_semantic_value(
     rdf_crypto.RDFX509Cert,
     "CA.certificate",
-    help="Trusted CA certificate in X509 pem format",
+    help="Trusted CA certificate in X509 pem format (messages)",
+)
+
+config_lib.DEFINE_semantic_value_list(
+    rdf_crypto.RDFX509Cert,
+    "Client.transport_ca_certificate",None,
+    "Trusted CA certificate in X509 pem format (transport)")
+
+config_lib.DEFINE_semantic_value(
+    rdf_crypto.RSAPrivateKey,
+    "Client.transport_private_key",
+    help="Client private key in pem format (transport, 2-way ssl)",
+)
+
+config_lib.DEFINE_semantic_value(
+    rdf_crypto.RDFX509Cert,
+    "Client.transport_public_certificate",
+    help="Client certificate in X509 pem format (transport, 2-way ssl)",
 )
 
 config_lib.DEFINE_semantic_value(

--- a/grr/core/grr_response_core/lib/config_lib.py
+++ b/grr/core/grr_response_core/lib/config_lib.py
@@ -1532,6 +1532,18 @@ class GrrConfigManager(object):
             validator=type_info.Integer()),
         constant=constant)
 
+  def DEFINE_semantic_value_list(self, semantic_type, name, default=None, help=""):
+    if issubclass(semantic_type, rdf_structs.RDFStruct):
+      raise ValueError("DEFINE_semantic_value_list should be used for types "
+                       "based on RDFValues.")
+    self.AddOption(
+        type_info.RDFValueList(
+            rdfclass=semantic_type,
+            name=name,
+            default=default,
+            validator=type_info.RDFValueType(rdfclass=semantic_type),
+            description=help))
+
   def DEFINE_list(self, name, default, help, constant=False):
     """A helper for defining lists of strings options."""
     self.AddOption(
@@ -1632,6 +1644,10 @@ def DEFINE_integer_list(name, default, help):
 def DEFINE_list(name, default, help):
   """A helper for defining lists of strings options."""
   _CONFIG.DEFINE_list(name, default, help)
+
+
+def DEFINE_semantic_value_list(semantic_type, name, default, help):
+  _CONFIG.DEFINE_semantic_value_list(semantic_type, name, default=default, help=help)
 
 
 def DEFINE_semantic_value(semantic_type, name, default=None, help=""):

--- a/grr/core/grr_response_core/lib/type_info.py
+++ b/grr/core/grr_response_core/lib/type_info.py
@@ -111,7 +111,6 @@ class TypeInfoObject(with_metaclass(registry.MetaclassRegistry, object)):
                                                        self.description,
                                                        self.GetDefault())
 
-
 class RDFValueType(TypeInfoObject):
   """An arg which must be an RDFValue."""
 
@@ -370,6 +369,21 @@ class List(TypeInfoObject):
   def ToString(self, value):
     return ",".join([self.validator.ToString(x) for x in value])
 
+
+class RDFValueList(List):
+  """A List of RDFValue."""
+  class _validator:
+    def __init__(self, validator=None):
+      self.validator = validator
+    def Validate(self, val):
+      try:
+        return self.validator.Validate(val.encode('utf-8'))
+      except Exception as e:
+        raise TypeValueError("Invalid data: %s" % e)
+  def __init__(self, rdfclass=None, validator=None, **kwargs):
+      super(RDFValueList, self).__init__(**kwargs)
+      self.validator = self._validator(validator)
+      self._type = self.rdfclass = rdfclass
 
 class String(TypeInfoObject):
   """A String type."""


### PR DESCRIPTION
Added 3 new Client context configuration:
- transport_ca_certificate: a list of PEM certificates to valide the
frontend certificate (transport)
- transport_private_key: a private key for client cert authentication
- transport_public_certificate: the certificate for client cert
authentication