### PR TITLE
Line 159 webauth.py - added source IP of the authentication attempt t…

### DIFF
--- a/grr/server/grr_response_server/gui/webauth.py
+++ b/grr/server/grr_response_server/gui/webauth.py
@@ -156,7 +156,7 @@ class RemoteUserWebAuthManager(BaseWebAuthManager):
   def SecurityCheck(self, func, request, *args, **kwargs):
     if request.remote_addr not in self.trusted_ips:
       return self.AuthError("Request sent from an IP not in "
-                            "AdminUI.remote_user_trusted_ips.")
+                            "AdminUI.remote_user_trusted_ips. Source was %s" % request.remote_addr)
 
     try:
       username = request.headers[self.remote_user_header]


### PR DESCRIPTION
To assist with troubleshooting remote auth issues - in my case, we were having issues with the F5's sending through requests in an odd format of ::ffff:10.x.x.x, whereas pcaps were showing the IPv4 10.x.x.x address. Adding this to our webauth.py so the source request address was displayed in the error let us figure out what was going on pretty quick.

This change isn't exposing trusted addresses for GRR - anyone able to connect directly to GRR would just see their own IP shown as source.