### PR TITLE
Aggregate GRR server components dashboards data

### DIFF
--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/admin_ui.json
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/admin_ui.json
@@ -107,7 +107,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -203,7 +203,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -299,7 +299,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -320,102 +320,6 @@
           "timeFrom": null,
           "timeShift": null,
           "title": "Sum of Process Memory Bytes (across all instances)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "show": true
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "grr-server",
-          "description": null,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "id": 4,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "sort": null,
-            "sortDesc": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": null,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "seriesOverrides": [],
-          "span": 3,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "",
-              "expr": "sum(rate(grr_client_crashes_total{job=\"grr_admin_ui\"}[10m]))",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Rate of Client crashes",
-              "metric": "",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "GRR Client Crashes",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -472,7 +376,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 5,
+          "id": 4,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -581,7 +485,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 6,
+          "id": 5,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -677,7 +581,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 7,
+          "id": 6,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -712,12 +616,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(db_request_errors_total{job=\"grr_admin_ui\"}[10m])",
+              "expr": "sum by (call) (rate(db_request_errors_total{job=\"grr_admin_ui\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Operations Error Rate - Call: {{call}}",
+              "legendFormat": "{{call}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -726,7 +630,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Database Operations Errors Rate",
+          "title": "Database Operations Errors Rate by Call",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -773,7 +677,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 8,
+          "id": 7,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -808,12 +712,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(db_request_latency_sum{job=\"grr_admin_ui\"}[10m]) / rate(db_request_latency_count{job=\"grr_admin_ui\"}[10m])",
+              "expr": "sum by (call) (rate(db_request_latency_sum{job=\"grr_admin_ui\"}[10m]) / rate(db_request_latency_count{job=\"grr_admin_ui\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Latency - Call: {{call}}",
+              "legendFormat": "{{call}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -822,7 +726,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Database Operations Latency",
+          "title": "Database Operations Latency by Call",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -879,6 +783,102 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "id": 8,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": null,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "",
+              "expr": "sum by (method_name) (rate(api_method_latency_sum[10m]) / rate(api_method_latency_count[10m]))",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{method_name}}",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "API Method Latency Rate by Method",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "grr-server",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 9,
           "isNew": true,
           "legend": {
@@ -914,12 +914,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(api_method_latency_sum[10m]) / rate(api_method_latency_count[10m])",
+              "expr": "sum(rate(api_method_latency_count{status=\"SUCCESS\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Latency - Method: {{method_name}}",
+              "legendFormat": "Successful Calls Rate",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -928,7 +928,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "API Method Latency Rate",
+          "title": "API Calls Count Rate with Status SUCCESS",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1010,12 +1010,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "sum(rate(api_method_latency_count{status=\"SUCCESS\"}[10m]))",
+              "expr": "sum by (method_name) (rate(api_method_latency_count{status!=\"SUCCESS\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Successful Calls Rate",
+              "legendFormat": "{{method_name}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1024,7 +1024,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "API Calls Count Rate by Status SUCCESS",
+          "title": "API Calls Count Rate with other statuses (not SUCCESS) by Method",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1106,12 +1106,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(api_method_latency_count{status!=\"SUCCESS\"}[10m])",
+              "expr": "sum by (method_name) (rate(api_access_probe_latency_sum[10m]) / rate(api_access_probe_latency_count[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Unsuccessful Calls Rate",
+              "legendFormat": "{{method_name}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1120,103 +1120,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "API Calls Count Rate by other statuses (not SUCCESS)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "show": true
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "grr-server",
-          "description": null,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "id": 12,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "sort": null,
-            "sortDesc": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": null,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "seriesOverrides": [],
-          "span": 3,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "",
-              "expr": "rate(api_access_probe_latency_sum[10m]) / rate(api_access_probe_latency_count[10m])",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Latency - Method: {{method_name}}",
-              "metric": "",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "API Access Probe Latency",
+          "title": "API Access Probe Latency by Method",
           "tooltip": {
             "msResolution": true,
             "shared": true,

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/frontends.json
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/frontends.json
@@ -107,7 +107,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -203,7 +203,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -299,7 +299,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -320,102 +320,6 @@
           "timeFrom": null,
           "timeShift": null,
           "title": "Sum of Process Memory Bytes (across all instances)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "show": true
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "grr-server",
-          "description": null,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "id": 4,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "sort": null,
-            "sortDesc": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": null,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "seriesOverrides": [],
-          "span": 3,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "",
-              "expr": "sum(rate(grr_client_crashes_total{job=\"grr_frontend\"}[10m]))",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Rate of Client crashes",
-              "metric": "",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "GRR Client Crashes",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -472,7 +376,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 5,
+          "id": 4,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -581,7 +485,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 6,
+          "id": 5,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -677,7 +581,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 7,
+          "id": 6,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -712,12 +616,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(db_request_errors_total{job=\"grr_frontend\"}[10m])",
+              "expr": "sum by (call) (rate(db_request_errors_total{job=\"grr_frontend\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Operations Error Rate - Call: {{call}}",
+              "legendFormat": "{{call}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -726,7 +630,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Database Operations Errors Rate",
+          "title": "Database Operations Errors Rate by Call",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -773,7 +677,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 8,
+          "id": 7,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -808,12 +712,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(db_request_latency_sum{job=\"grr_frontend\"}[10m]) / rate(db_request_latency_count{job=\"grr_frontend\"}[10m])",
+              "expr": "sum by (call) (rate(db_request_latency_sum{job=\"grr_frontend\"}[10m]) / rate(db_request_latency_count{job=\"grr_frontend\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Latency - Call: {{call}}",
+              "legendFormat": "{{call}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -822,7 +726,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Database Operations Latency",
+          "title": "Database Operations Latency by Call",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -879,6 +783,102 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "id": 8,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": null,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "",
+              "expr": "sum(rate(frontend_request_count_total[1m]))",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Requests",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": ""
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "QPS",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "grr-server",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 9,
           "isNew": true,
           "legend": {
@@ -908,18 +908,18 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 4,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "datasource": "",
-              "expr": "sum(rate(frontend_request_count_total[1m]))",
+              "expr": "sum(rate(frontend_request_latency_sum[10m])) / sum(rate(frontend_request_latency_count[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Requests",
+              "legendFormat": "Latency",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -928,7 +928,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "QPS",
+          "title": "Request Latency Rate",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1004,18 +1004,18 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 4,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "datasource": "",
-              "expr": "sum(rate(frontend_request_latency_sum[10m])) / sum(rate(frontend_request_latency_count[10m]))",
+              "expr": "sum by (flow) (rate(well_known_flow_requests_total[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Latency",
+              "legendFormat": "{{flow}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1024,7 +1024,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Request Latency Rate",
+          "title": "Well Known Flows Requests Rate by Flow",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1100,18 +1100,18 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 4,
+          "span": 3,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(well_known_flow_requests_total[10m])",
+              "expr": "sum(rate(grr_client_crashes_total{job=\"grr_frontend\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Flow: {{flow}}",
+              "legendFormat": "Rate of Client crashes",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1120,7 +1120,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Well Known Flows Requests Rate",
+          "title": "GRR Client Crashes",
           "tooltip": {
             "msResolution": true,
             "shared": true,

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/workers.json
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/workers.json
@@ -1036,7 +1036,7 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(grr_worker_states_run_total{job=\"grr_worker\"}[10m])",
+              "expr": "sum by (instance) (rate(grr_worker_states_run_total{job=\"grr_worker\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/workers.json
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_for_use/workers.json
@@ -107,7 +107,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -203,7 +203,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -299,7 +299,7 @@
           "renderer": "flot",
           "repeat": null,
           "seriesOverrides": [],
-          "span": 3,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -320,102 +320,6 @@
           "timeFrom": null,
           "timeShift": null,
           "title": "Sum of Process Memory Bytes (across all instances)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "show": true
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "grr-server",
-          "description": null,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "id": 4,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "sort": null,
-            "sortDesc": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": null,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "seriesOverrides": [],
-          "span": 3,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "",
-              "expr": "sum(rate(grr_client_crashes_total{job=\"grr_worker\"}[10m]))",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "Rate of Client crashes",
-              "metric": "",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "GRR Client Crashes",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -472,7 +376,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 5,
+          "id": 4,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -581,7 +485,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 6,
+          "id": 5,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -677,7 +581,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 7,
+          "id": 6,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -712,12 +616,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(db_request_errors_total{job=\"grr_worker\"}[10m])",
+              "expr": "sum by (call) (rate(db_request_errors_total{job=\"grr_worker\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Operations Error Rate - Call: {{call}}",
+              "legendFormat": "{{call}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -726,7 +630,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Database Operations Errors Rate",
+          "title": "Database Operations Errors Rate by Call",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -773,7 +677,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 8,
+          "id": 7,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -808,12 +712,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "rate(db_request_latency_sum{job=\"grr_worker\"}[10m]) / rate(db_request_latency_count{job=\"grr_worker\"}[10m])",
+              "expr": "sum by (call) (rate(db_request_latency_sum{job=\"grr_worker\"}[10m]) / rate(db_request_latency_count{job=\"grr_worker\"}[10m]))",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Latency - Call: {{call}}",
+              "legendFormat": "{{call}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -822,7 +726,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Database Operations Latency",
+          "title": "Database Operations Latency by Call",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -879,7 +783,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 9,
+          "id": 8,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -988,7 +892,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 10,
+          "id": 9,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -1097,7 +1001,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 11,
+          "id": 10,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -1137,7 +1041,7 @@
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Rate of Fow States moved through",
+              "legendFormat": "{{instance}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1146,7 +1050,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Rate of Flow States a GRR Worker has moved through",
+          "title": "Rate of Flow States a GRR Worker has moved through by GRR Worker Instance",
           "tooltip": {
             "msResolution": true,
             "shared": true,

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
@@ -41,11 +41,11 @@ dashboard = Dashboard(
         ],
       ),
       Graph(
-        title="API Access Probe Latency",
+        title="API Access Probe Latency by Method",
         targets=[
           Target(
-            expr='rate(api_access_probe_latency_sum[10m]) / rate(api_access_probe_latency_count[10m])',
-            legendFormat="Latency - Method: {{method_name}}",
+            expr='sum by (method_name) (rate(api_access_probe_latency_sum[10m]) / rate(api_access_probe_latency_count[10m]))',
+            legendFormat="{{method_name}}",
           ),
         ],
       ),

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
@@ -14,11 +14,11 @@ dashboard = Dashboard(
     [
     Row(panels=[
       Graph(
-        title="API Method Latency Rate",
+        title="API Method Latency Rate by Method",
         targets=[
           Target(
-            expr='rate(api_method_latency_sum[10m]) / rate(api_method_latency_count[10m])',
-            legendFormat="Latency - Method: {{method_name}}",
+            expr='sum by (method_name) (rate(api_method_latency_sum[10m]) / rate(api_method_latency_count[10m]))',
+            legendFormat="{{method_name}}",
           ),
         ],
       ),

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
@@ -32,11 +32,11 @@ dashboard = Dashboard(
         ],
       ),
       Graph(
-        title="API Calls Count Rate with other statuses (not SUCCESS)",
+        title="API Calls Count Rate with other statuses (not SUCCESS) by Method",
         targets=[
           Target(
-            expr='rate(api_method_latency_count{status!="SUCCESS"}[10m])',
-            legendFormat="Unsuccessful Calls Rate",
+            expr='sum by (method_name) (rate(api_method_latency_count{status!="SUCCESS"}[10m]))',
+            legendFormat="{{method_name}}",
           ),
         ],
       ),

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/admin_ui.dashboard.py
@@ -23,7 +23,7 @@ dashboard = Dashboard(
         ],
       ),
       Graph(
-        title="API Calls Count Rate by Status SUCCESS",
+        title="API Calls Count Rate with Status SUCCESS",
         targets=[
           Target(
             expr='sum(rate(api_method_latency_count{status="SUCCESS"}[10m]))',
@@ -32,7 +32,7 @@ dashboard = Dashboard(
         ],
       ),
       Graph(
-        title="API Calls Count Rate by other statuses (not SUCCESS)",
+        title="API Calls Count Rate with other statuses (not SUCCESS)",
         targets=[
           Target(
             expr='rate(api_method_latency_count{status!="SUCCESS"}[10m])',

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/frontends.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/frontends.dashboard.py
@@ -32,11 +32,11 @@ dashboard = Dashboard(
         ],
       ),
       Graph(
-        title="Well Known Flows Requests Rate",
+        title="Well Known Flows Requests Rate by Flow",
         targets=[
           Target(
-            expr='rate(well_known_flow_requests_total[10m])',
-            legendFormat="Flow: {{flow}}",
+            expr='sum by (flow) (rate(well_known_flow_requests_total[10m]))',
+            legendFormat="{{flow}}",
           ),
         ],
       ),

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/workers.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/workers.dashboard.py
@@ -43,7 +43,7 @@ dashboard = Dashboard(
         title="Rate of Flow States a GRR Worker has moved through by GRR Worker Instance",
         targets=[
           Target(
-            expr='rate(grr_worker_states_run_total{job="grr_worker"}[10m])',
+            expr='sum by (instance) (rate(grr_worker_states_run_total{job="grr_worker"}[10m]))',
             legendFormat="{{instance}}",
           ),
         ],

--- a/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/workers.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/dashboards_to_generate/workers.dashboard.py
@@ -40,11 +40,11 @@ dashboard = Dashboard(
         ],
       ),
       Graph(
-        title="Rate of Flow States a GRR Worker has moved through",
+        title="Rate of Flow States a GRR Worker has moved through by GRR Worker Instance",
         targets=[
           Target(
             expr='rate(grr_worker_states_run_total{job="grr_worker"}[10m])',
-            legendFormat="Rate of Fow States moved through",
+            legendFormat="{{instance}}",
           ),
         ],
       ),

--- a/monitoring/grafana/grr_grafanalib_dashboards/reusable_panels.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/reusable_panels.py
@@ -54,11 +54,11 @@ def sum_process_memory_bytes(grr_component):
 
 def db_operations_latency(grr_component):
   return Graph(
-    title="Database Operations Latency",
+    title="Database Operations Latency by Call",
     targets=[
       Target(
-        expr='rate(db_request_latency_sum{{job="grr_{0}"}}[10m]) / rate(db_request_latency_count{{job="grr_{0}"}}[10m])'.format(grr_component),
-        legendFormat="Latency - Call: {{call}}",
+        expr='sum by (call) (rate(db_request_latency_sum{{job="grr_{0}"}}[10m]) / rate(db_request_latency_count{{job="grr_{0}"}}[10m]))'.format(grr_component),
+        legendFormat="{{call}}",
       ),
     ])
 

--- a/monitoring/grafana/grr_grafanalib_dashboards/reusable_panels.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/reusable_panels.py
@@ -64,11 +64,11 @@ def db_operations_latency(grr_component):
 
 def db_operations_errors(grr_component):
   return Graph(
-    title="Database Operations Errors Rate",
+    title="Database Operations Errors Rate by Call",
     targets=[
       Target(
-        expr='rate(db_request_errors_total{{job="grr_{0}"}}[10m])'.format(grr_component),
-        legendFormat="Operations Error Rate - Call: {{call}}",
+        expr='sum by (call) (rate(db_request_errors_total{{job="grr_{0}"}}[10m]))'.format(grr_component),
+        legendFormat="{{call}}",
       ),
     ])
 


### PR DESCRIPTION
The panels and graphs in the previously submitted Grafana dashboards (see #787 and the rest of the corresponding PRs) were not all aggregated by some label. What this practically means is that some graphs would explode if more GRR server component instances were to be added to a deployment.
We want to change that so the number of lines in a certain graph would not depend on the number of instances of a certain GRR server component (for example, can be other labels as well).

For example; for the graph "API Method Latency Rate" in the AdminUI dashboard, if it would not be aggregated (the existing situation), then if _x_ more AdminUI instances were in the deployment, each instance with about _y_ different API methods used, then the graph would have _xy_ lines, which can be a lot depending on the deployment. (The actual number will be larger since the instance is only one thing that separates different lines in a graph; lines can be separated also by protocol, status etc.).

**Note** that this is not the case for all graphs; for instance, in the graph for "Rate of Flow States a GRR Worker has moved through", we do want to aggregate by separate Worker instances; but only by the instances and not other labels, so the graph is manageable.