### PR TITLE
Add format argument for hunt timelines collection

### DIFF
--- a/api_client/python/grr_api_client/hunt.py
+++ b/api_client/python/grr_api_client/hunt.py
@@ -280,9 +280,12 @@ class HuntBase(object):
         hunt_id=self.hunt_id, plugin_name=plugin_name)
     return self._context.SendStreamingRequest("GetExportedHuntResults", args)
 
-  def GetCollectedTimelines(self):
+  def GetCollectedTimelines(
+      self,
+      format=timeline_pb2.ApiGetCollectedTimelineArgs.Format.RAW_GZCHUNKED):
     args = timeline_pb2.ApiGetCollectedHuntTimelinesArgs()
     args.hunt_id = self.hunt_id
+    args.format = format
 
     return self._context.SendStreamingRequest("GetCollectedHuntTimelines", args)
 

--- a/grr/proto/grr_response_proto/api/timeline.proto
+++ b/grr/proto/grr_response_proto/api/timeline.proto
@@ -51,4 +51,7 @@ message ApiGetCollectedTimelineArgs {
 message ApiGetCollectedHuntTimelinesArgs {
   // An identifier of the hunt for which to retrieve results.
   optional string hunt_id = 1;
+  
+  // A format in which to retrieve timeline entries.
+  optional ApiGetCollectedTimelineArgs.Format format = 2;
 }

--- a/grr/server/grr_response_server/gui/api_call_router.py
+++ b/grr/server/grr_response_server/gui/api_call_router.py
@@ -948,13 +948,13 @@ class ApiCallRouterStub(ApiCallRouter):
   @Category("Hunts")
   @ArgsType(api_timeline.ApiGetCollectedHuntTimelinesArgs)
   @ResultBinaryStream()
-  @Http("GET", "/api/hunts/<hunt_id>/timelines")
+  @Http("GET", "/api/hunts/<hunt_id>/timelines/<format>")
   def GetCollectedHuntTimelines(
       self,
       args: api_timeline.ApiGetCollectedHuntTimelinesArgs,
       token: Optional[access_control.ACLToken] = None,
   ) -> api_timeline.ApiGetCollectedHuntTimelinesHandler:
-    """Exports results of a timeline hunt as a ZIP archive."""
+    """Exports results of a timeline hunt using the format as a ZIP archive."""
     raise NotImplementedError()
 
   # Stats metrics methods.

--- a/grr/server/grr_response_server/gui/api_call_router.py
+++ b/grr/server/grr_response_server/gui/api_call_router.py
@@ -954,7 +954,11 @@ class ApiCallRouterStub(ApiCallRouter):
       args: api_timeline.ApiGetCollectedHuntTimelinesArgs,
       token: Optional[access_control.ACLToken] = None,
   ) -> api_timeline.ApiGetCollectedHuntTimelinesHandler:
-    """Exports results of a timeline hunt using the format as a ZIP archive."""
+    """Exports results of a timeline hunt.
+
+    The results are exported as a ZIP archive whose files follow the specified
+    format.
+    """
     raise NotImplementedError()
 
   # Stats metrics methods.

--- a/grr/server/grr_response_server/gui/api_integration_tests/hunt_test.py
+++ b/grr/server/grr_response_server/gui/api_integration_tests/hunt_test.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import csv
 import io
+import stat
 import zipfile
 
 from absl import app
@@ -331,7 +332,7 @@ class ApiClientLibHuntTest(
 
         self.assertEqual(rows[0][1], "/bar/baz/quux")
         self.assertEqual(rows[0][2], "5926273453")
-        self.assertEqual(rows[0][3], "?rw-rw-r--")
+        self.assertEqual(rows[0][3], stat.filemode(0o664))
         self.assertEqual(rows[0][6], "13373")
         self.assertEqual(rows[0][7], "111")
         self.assertEqual(rows[0][8], "222")
@@ -339,7 +340,7 @@ class ApiClientLibHuntTest(
 
         self.assertEqual(rows[1][1], "/bar/baz/quuz")
         self.assertEqual(rows[1][2], "6037384564")
-        self.assertEqual(rows[1][3], "?rwxrwxrwx")
+        self.assertEqual(rows[1][3], stat.filemode(0o777))
         self.assertEqual(rows[1][6], "13374")
         self.assertEqual(rows[1][7], "777")
         self.assertEqual(rows[1][8], "888")
@@ -374,13 +375,21 @@ class ApiClientLibHuntTest(
 
     entry_1 = rdf_timeline.TimelineEntry()
     entry_1.path = "/foo/bar".encode("utf-8")
+    entry_1.ino = 7890178901
     entry_1.size = 4815162342
-    entry_1.mode = 0o664
+    entry_1.atime_ns = 123 * 10**9
+    entry_1.mtime_ns = 234 * 10**9
+    entry_1.ctime_ns = 567 * 10**9
+    entry_1.mode = 0o654
 
     entry_2 = rdf_timeline.TimelineEntry()
     entry_2.path = "/foo/baz".encode("utf-8")
+    entry_1.ino = 8765487654
     entry_2.size = 1337
-    entry_2.mode = 0o777
+    entry_1.atime_ns = 987 * 10**9
+    entry_1.mtime_ns = 876 * 10**9
+    entry_1.ctime_ns = 765 * 10**9
+    entry_2.mode = 0o757
 
     entries = [entry_1, entry_2]
     blobs = list(rdf_timeline.TimelineEntry.SerializeStream(iter(entries)))

--- a/grr/server/grr_response_server/gui/api_integration_tests/hunt_test.py
+++ b/grr/server/grr_response_server/gui/api_integration_tests/hunt_test.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+import csv
 import io
 import zipfile
 
@@ -13,6 +14,7 @@ from absl import app
 from grr_response_core.lib import rdfvalue
 from grr_response_core.lib.rdfvalues import timeline as rdf_timeline
 from grr_response_core.lib.util import chunked
+from grr_response_proto.api import timeline_pb2
 from grr_response_server import data_store
 from grr_response_server.databases import db
 from grr_response_server.databases import db_test_utils
@@ -26,6 +28,7 @@ from grr_response_server.rdfvalues import objects as rdf_objects
 from grr.test_lib import flow_test_lib
 from grr.test_lib import hunt_test_lib
 from grr.test_lib import test_lib
+
 
 
 class ApiClientLibHuntTest(
@@ -255,7 +258,94 @@ class ApiClientLibHuntTest(
     namelist = zip_fd.namelist()
     self.assertTrue(namelist)
 
-  def testGetCollectedTimelines(self):
+  def testGetCollectedTimelinesBody(self):
+    client_id = db_test_utils.InitializeClient(data_store.REL_DB)
+    fqdn = "foo.bar.quux"
+
+    snapshot = rdf_objects.ClientSnapshot()
+    snapshot.client_id = client_id
+    snapshot.knowledge_base.fqdn = fqdn
+    data_store.REL_DB.WriteClientSnapshot(snapshot)
+
+    hunt_id = "B1C2E3D4F5"
+    flow_id = "1B2C3E4D5F"
+
+    hunt_obj = rdf_hunt_objects.Hunt()
+    hunt_obj.hunt_id = hunt_id
+    hunt_obj.args.standard.client_ids = [client_id]
+    hunt_obj.args.standard.flow_name = timeline.TimelineFlow.__name__
+    hunt_obj.hunt_state = rdf_hunt_objects.Hunt.HuntState.PAUSED
+    data_store.REL_DB.WriteHuntObject(hunt_obj)
+
+    flow_obj = rdf_flow_objects.Flow()
+    flow_obj.client_id = client_id
+    flow_obj.flow_id = flow_id
+    flow_obj.flow_class_name = timeline.TimelineFlow.__name__
+    flow_obj.create_time = rdfvalue.RDFDatetime.Now()
+    flow_obj.parent_hunt_id = hunt_id
+    data_store.REL_DB.WriteFlowObject(flow_obj)
+
+    entry_1 = rdf_timeline.TimelineEntry()
+    entry_1.path = "/bar/baz/quux".encode("utf-8")
+    entry_1.ino = 5926273453
+    entry_1.size = 13373
+    entry_1.atime_ns = 111 * 10**9
+    entry_1.mtime_ns = 222 * 10**9
+    entry_1.ctime_ns = 333 * 10**9
+    entry_1.mode = 0o664
+
+    entry_2 = rdf_timeline.TimelineEntry()
+    entry_2.path = "/bar/baz/quuz".encode("utf-8")
+    entry_2.ino = 6037384564
+    entry_2.size = 13374
+    entry_2.atime_ns = 777 * 10**9
+    entry_2.mtime_ns = 888 * 10**9
+    entry_2.ctime_ns = 999 * 10**9
+    entry_2.mode = 0o777
+
+    entries = [entry_1, entry_2]
+    blobs = list(rdf_timeline.TimelineEntry.SerializeStream(iter(entries)))
+    blob_ids = data_store.BLOBS.WriteBlobsWithUnknownHashes(blobs)
+
+    result = rdf_timeline.TimelineResult()
+    result.entry_batch_blob_ids = [blob_id.AsBytes() for blob_id in blob_ids]
+
+    flow_result = rdf_flow_objects.FlowResult()
+    flow_result.client_id = client_id
+    flow_result.flow_id = flow_id
+    flow_result.payload = result
+
+    data_store.REL_DB.WriteFlowResults([flow_result])
+
+    buffer = io.BytesIO()
+    self.api.Hunt(hunt_id).GetCollectedTimelines(
+        timeline_pb2.ApiGetCollectedTimelineArgs.Format.BODY).WriteToStream(
+            buffer)
+
+    with zipfile.ZipFile(buffer, mode="r") as archive:
+      with archive.open(f"{client_id}_{fqdn}.body", mode="r") as file:
+        content_file = file.read().decode("utf-8")
+
+        rows = list(csv.reader(io.StringIO(content_file), delimiter="|"))
+        self.assertLen(rows, 2)
+
+        self.assertEqual(rows[0][1], "/bar/baz/quux")
+        self.assertEqual(rows[0][2], "5926273453")
+        self.assertEqual(rows[0][3], "?rw-rw-r--")
+        self.assertEqual(rows[0][6], "13373")
+        self.assertEqual(rows[0][7], "111")
+        self.assertEqual(rows[0][8], "222")
+        self.assertEqual(rows[0][9], "333")
+
+        self.assertEqual(rows[1][1], "/bar/baz/quuz")
+        self.assertEqual(rows[1][2], "6037384564")
+        self.assertEqual(rows[1][3], "?rwxrwxrwx")
+        self.assertEqual(rows[1][6], "13374")
+        self.assertEqual(rows[1][7], "777")
+        self.assertEqual(rows[1][8], "888")
+        self.assertEqual(rows[1][9], "999")
+
+  def testGetCollectedTimelinesGzchunked(self):
     client_id = db_test_utils.InitializeClient(data_store.REL_DB)
     fqdn = "foo.bar.baz"
 
@@ -307,7 +397,9 @@ class ApiClientLibHuntTest(
     data_store.REL_DB.WriteFlowResults([flow_result])
 
     buffer = io.BytesIO()
-    self.api.Hunt(hunt_id).GetCollectedTimelines().WriteToStream(buffer)
+    self.api.Hunt(hunt_id).GetCollectedTimelines(
+      timeline_pb2.ApiGetCollectedTimelineArgs.Format.RAW_GZCHUNKED
+    ).WriteToStream(buffer)
 
     with zipfile.ZipFile(buffer, mode="r") as archive:
       with archive.open(f"{client_id}_{fqdn}.gzchunked", mode="r") as file:

--- a/grr/server/grr_response_server/gui/api_plugins/timeline.py
+++ b/grr/server/grr_response_server/gui/api_plugins/timeline.py
@@ -111,6 +111,11 @@ class ApiGetCollectedHuntTimelinesHandler(api_call_handler_base.ApiCallHandler):
       message = f"Hunt '{hunt_id}' is not a timeline hunt"
       raise ValueError(message)
 
+    if (args.format != ApiGetCollectedTimelineArgs.Format.RAW_GZCHUNKED) and (
+        args.format != ApiGetCollectedTimelineArgs.Format.BODY):
+      message = f"Incorrect timeline export format {args.format}"
+      raise ValueError(message)
+
     filename = f"timelines_{hunt_id}.zip"
     content = self._Generate(hunt_id, args.format)
     return api_call_handler_base.ApiBinaryStream(filename, content)
@@ -118,7 +123,7 @@ class ApiGetCollectedHuntTimelinesHandler(api_call_handler_base.ApiCallHandler):
   def _Generate(
       self,
       hunt_id: Text,
-      format: ApiGetCollectedTimelineArgs.Format
+      format: ApiGetCollectedTimelineArgs.Format,
   ) -> Iterator[bytes]:
     zipgen = utils.StreamingZipGenerator()
     yield from self._GenerateTimelines(hunt_id, format, zipgen)
@@ -168,10 +173,11 @@ class ApiGetCollectedHuntTimelinesHandler(api_call_handler_base.ApiCallHandler):
 
     if format == ApiGetCollectedTimelineArgs.Format.RAW_GZCHUNKED:
       filename = f"{client_id}_{fqdn}.gzchunked"
-    elif format == ApiGetCollectedTimelineArgs.Format.BODY:  # pytype: disable=attribute-error
+    elif format == ApiGetCollectedTimelineArgs.Format.BODY:
       filename = f"{client_id}_{fqdn}.body"
     else:
-      message = "Incorrect timeline export format: {}".format(format)
+      message = "Unknown file extension for timeline export format: {}".format(
+          format)
       raise ValueError(message)
 
     yield zipgen.WriteFileHeader(filename)

--- a/grr/server/grr_response_server/gui/api_plugins/timeline.py
+++ b/grr/server/grr_response_server/gui/api_plugins/timeline.py
@@ -176,8 +176,7 @@ class ApiGetCollectedHuntTimelinesHandler(api_call_handler_base.ApiCallHandler):
     elif format == ApiGetCollectedTimelineArgs.Format.BODY:
       filename = f"{client_id}_{fqdn}.body"
     else:
-      message = "Unknown file extension for timeline export format: {}".format(
-          format)
+      message = f"Unknown file extension for timeline export format: {format}"
       raise ValueError(message)
 
     yield zipgen.WriteFileHeader(filename)

--- a/grr/server/grr_response_server/gui/api_plugins/timeline.py
+++ b/grr/server/grr_response_server/gui/api_plugins/timeline.py
@@ -111,7 +111,7 @@ class ApiGetCollectedHuntTimelinesHandler(api_call_handler_base.ApiCallHandler):
       message = f"Hunt '{hunt_id}' is not a timeline hunt"
       raise ValueError(message)
 
-    if (args.format != ApiGetCollectedTimelineArgs.Format.RAW_GZCHUNKED) and (
+    if (args.format != ApiGetCollectedTimelineArgs.Format.RAW_GZCHUNKED and
         args.format != ApiGetCollectedTimelineArgs.Format.BODY):
       message = f"Incorrect timeline export format {args.format}"
       raise ValueError(message)
@@ -176,8 +176,7 @@ class ApiGetCollectedHuntTimelinesHandler(api_call_handler_base.ApiCallHandler):
     elif format == ApiGetCollectedTimelineArgs.Format.BODY:
       filename = f"{client_id}_{fqdn}.body"
     else:
-      message = f"Unknown file extension for timeline export format: {format}"
-      raise ValueError(message)
+      raise AssertionError()
 
     yield zipgen.WriteFileHeader(filename)
 


### PR DESCRIPTION
- Update the ApiGetCollectedHuntTimelinesArgs protobuf message to hold the format
- Update the API router and handler
- Update the Python API client to accept the format argument
- Update/Add tests