### PR TITLE
Update timestamp in UIv2 to show absolute timestamp for short format

### DIFF
--- a/grr/server/grr_response_server/gui/ui/components/client/client.ng.html
+++ b/grr/server/grr_response_server/gui/ui/components/client/client.ng.html
@@ -19,7 +19,7 @@
        {{client.knowledgeBase.os}}
     </div>
     <div class="last-seen">
-      Last seen: <timestamp [date]="client.lastSeenAt" absoluteOnly="true"></timestamp>
+      Last seen: <timestamp [date]="client.lastSeenAt" completeFormat="true"></timestamp>
     </div>
   </div>
   <div class="client-approval">

--- a/grr/server/grr_response_server/gui/ui/components/client_search/client_search_test.ts
+++ b/grr/server/grr_response_server/gui/ui/components/client_search/client_search_test.ts
@@ -115,10 +115,10 @@ describe('ClientSearch Component', () => {
     // Check the first data row.
     expect(htmlCollectionToList(rows[1].getElementsByTagName('td'))
       .map((e: Element) => (e as HTMLElement).innerText))
-      .toEqual(['C.1234', 'foo.unknown', new RelativeTimestampPipe().transform(new Date(1571789996678), false)]);
+      .toEqual(['C.1234', 'foo.unknown', '2019-10-23 00:19:56 UTC']);
     // Check the second data row.
     expect(htmlCollectionToList(rows[2].getElementsByTagName('td'))
       .map((e: Element) => (e as HTMLElement).innerText))
-      .toEqual(['C.5678', 'bar.unknown', '-']);
+      .toEqual(['C.5678', 'bar.unknown', '- UTC']);
   });
 });

--- a/grr/server/grr_response_server/gui/ui/components/client_search/client_search_test.ts
+++ b/grr/server/grr_response_server/gui/ui/components/client_search/client_search_test.ts
@@ -119,6 +119,6 @@ describe('ClientSearch Component', () => {
     // Check the second data row.
     expect(htmlCollectionToList(rows[2].getElementsByTagName('td'))
       .map((e: Element) => (e as HTMLElement).innerText))
-      .toEqual(['C.5678', 'bar.unknown', '- UTC']);
+      .toEqual(['C.5678', 'bar.unknown', 'Unknown']);
   });
 });

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/module.ts
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/module.ts
@@ -3,6 +3,9 @@ import {NgModule} from '@angular/core';
 import {Timestamp} from './timestamp';
 import {RelativeTimestampPipe} from './relative_timestamp_pipe';
 import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {ClipboardModule} from '@angular/cdk/clipboard';
 
 /**
  * Module for the flow_picker details component.
@@ -12,6 +15,9 @@ import {MatTooltipModule} from '@angular/material/tooltip';
     // Angular builtin modules.
     CommonModule,
     MatTooltipModule,
+    MatIconModule,
+    MatButtonModule,
+    ClipboardModule,
   ],
   declarations: [
     Timestamp,

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/relative_timestamp_pipe.ts
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/relative_timestamp_pipe.ts
@@ -5,53 +5,16 @@ import {DateTime} from 'luxon';
   name: 'relativeTimestamp'
 })
 export class RelativeTimestampPipe implements PipeTransform {
-  private static readonly ONE_DAY_IN_MILLIS = 86400000;
-  private static readonly ONE_HOUR_IN_MILLIS = 3600000;
-  private static readonly ONE_MIN_IN_MILLIS = 60000;
-  private static readonly ONE_SECOND_IN_MILLIS = 1000;
+  private static readonly UNDEFINED_TIMESTAMP = '-';
 
-  transform(jsDate: Date, absoluteOnly: boolean): string {
-    if (jsDate === undefined) {
-      return '-';
-    }
-
+  transform(jsDate: Date): string {
     const date = DateTime.fromJSDate(jsDate);
+    const relativeTimestamp = date.toRelative();
 
-    if (absoluteOnly) {
-      return this.getAbsoluteTimestamp(date);
+    if (relativeTimestamp === null) {
+      return RelativeTimestampPipe.UNDEFINED_TIMESTAMP;
     }
 
-    const now = DateTime.local();
-    const timeElapsed = now.diff(date, 'milliseconds').as('milliseconds');
-
-    if (timeElapsed < RelativeTimestampPipe.ONE_MIN_IN_MILLIS / 2) {
-      return "Just now";
-    }
-
-    if (timeElapsed < RelativeTimestampPipe.ONE_MIN_IN_MILLIS) {
-      return `${Math.floor(timeElapsed / RelativeTimestampPipe.ONE_SECOND_IN_MILLIS)} seconds ago`;
-    }
-
-    if (timeElapsed < RelativeTimestampPipe.ONE_HOUR_IN_MILLIS) {
-      return `${Math.floor(timeElapsed / RelativeTimestampPipe.ONE_MIN_IN_MILLIS)}min ago`;
-    }
-
-    if (timeElapsed < RelativeTimestampPipe.ONE_DAY_IN_MILLIS) {
-      let timeDiff = now.diff(date, ['hours', 'minutes']);
-
-      return `${timeDiff.hours}h${Math.floor(timeDiff.minutes)}min ago`
-    }
-
-    let yesterdayDate = now.minus({days: 1});
-    if (yesterdayDate.hasSame(date, 'year') && yesterdayDate.hasSame(date, 'month') &&
-      yesterdayDate.hasSame(date, 'day')) {
-      return `yesterday at ${date.toLocaleString(DateTime.TIME_24_SIMPLE)}`;
-    }
-
-    return this.getAbsoluteTimestamp(date);
-  }
-
-  getAbsoluteTimestamp(date: DateTime): any {
-    return date.toLocaleString(DateTime.DATETIME_MED);
+    return relativeTimestamp;
   }
 }

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
@@ -1,4 +1,5 @@
-<div class="timestamp"
+<div *ngIf="date !== undefined; else dateUndefined"
+  class="timestamp"
   [matTooltip]="date | relativeTimestamp"
   matTooltipPosition="above"
   matTooltipClass="tooltip"
@@ -8,16 +9,10 @@
 
   <div class="inline_relative" *ngIf="completeFormat">
     {{date | relativeTimestamp}}
-
     <button mat-icon-button class="copy_button"
-      (click)="copyTooltip.show()"
       [cdkCopyToClipboard]="(date | date:'yyyy-MM-dd HH:mm:ss':timezone) + ' ' + timezone">
-
-      <div matTooltip="Copied!"
-        #copyTooltip="matTooltip"
-        matTooltipPosition="above">
-      </div>
       <mat-icon aria-label="Copy">content_copy</mat-icon>
     </button>
   </div>
 </div>
+<ng-template #dateUndefined><span>Unknown</span></ng-template>

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
@@ -4,6 +4,6 @@
   matTooltipClass="tooltip"
   [matTooltipDisabled]="completeFormat || !tooltipEnabled"
   [style.border-bottom]="(completeFormat || !tooltipEnabled) ? 'none' : '1px dotted rgb(126, 126, 126)'">
-  {{ date | date:'yyyy-MM-dd HH:mm:ss':'utc' }} UTC
-  <div class="inline_relative" *ngIf="completeFormat">{{ date | relativeTimestamp }}</div>
+  {{date | date:'yyyy-MM-dd HH:mm:ss':timezone}} {{timezone}}
+  <div class="inline_relative" *ngIf="completeFormat">{{date | relativeTimestamp}}</div>
 </div>

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
@@ -1,8 +1,9 @@
 <div class="timestamp"
-  matTooltip="{{ date | relativeTimestamp }}"
+  [matTooltip]="date | relativeTimestamp"
   matTooltipPosition="above"
   matTooltipClass="tooltip"
-  matTooltipDisabled="{{ !tooltipEnabled }}"
-  [style.border-bottom]="tooltipEnabled ? '1px dotted rgb(126, 126, 126)' : 'none'">
+  [matTooltipDisabled]="completeFormat || !tooltipEnabled"
+  [style.border-bottom]="(completeFormat || !tooltipEnabled) ? 'none' : '1px dotted rgb(126, 126, 126)'">
   {{ date | date:'yyyy-MM-dd HH:mm:ss':'utc' }} UTC
+  <div class="inline_relative" *ngIf="completeFormat">{{ date | relativeTimestamp }}</div>
 </div>

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
@@ -1,8 +1,8 @@
 <div class="timestamp"
-  matTooltip="{{date | date:'yyyy-MM-dd HH:mm:ss':'utc'}} UTC"
+  matTooltip="{{ date | relativeTimestamp }}"
   matTooltipPosition="above"
   matTooltipClass="tooltip"
-  matTooltipDisabled="{{!tooltipEnabled}}"
+  matTooltipDisabled="{{ !tooltipEnabled }}"
   [style.border-bottom]="tooltipEnabled ? '1px dotted rgb(126, 126, 126)' : 'none'">
-  {{date | relativeTimestamp: absoluteOnly}}
+  {{ date | date:'yyyy-MM-dd HH:mm:ss':'utc' }} UTC
 </div>

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
@@ -17,7 +17,7 @@
         #copyTooltip="matTooltip"
         matTooltipPosition="above">
       </div>
-      <mat-icon>content_copy</mat-icon>
+      <mat-icon aria-label="Copy">content_copy</mat-icon>
     </button>
   </div>
 </div>

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ng.html
@@ -5,5 +5,19 @@
   [matTooltipDisabled]="completeFormat || !tooltipEnabled"
   [style.border-bottom]="(completeFormat || !tooltipEnabled) ? 'none' : '1px dotted rgb(126, 126, 126)'">
   {{date | date:'yyyy-MM-dd HH:mm:ss':timezone}} {{timezone}}
-  <div class="inline_relative" *ngIf="completeFormat">{{date | relativeTimestamp}}</div>
+
+  <div class="inline_relative" *ngIf="completeFormat">
+    {{date | relativeTimestamp}}
+
+    <button mat-icon-button class="copy_button"
+      (click)="copyTooltip.show()"
+      [cdkCopyToClipboard]="(date | date:'yyyy-MM-dd HH:mm:ss':timezone) + ' ' + timezone">
+
+      <div matTooltip="Copied!"
+        #copyTooltip="matTooltip"
+        matTooltipPosition="above">
+      </div>
+      <mat-icon>content_copy</mat-icon>
+    </button>
+  </div>
 </div>

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.scss
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.scss
@@ -1,3 +1,5 @@
+@use '~material-theme' as c;
+
 .timestamp {
   position: relative;
   display: inline-block;
@@ -5,4 +7,9 @@
 
 .tooltip {
   margin-bottom: 3px !important;
+}
+
+.inline_relative {
+  display: inline-block;
+  color: c.mat-color(c.$foreground, text-light);
 }

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.scss
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.scss
@@ -1,7 +1,6 @@
 @use '~material-theme' as c;
 
 .timestamp {
-  position: relative;
   display: inline-block;
 }
 
@@ -15,5 +14,5 @@
 }
 
 .copy_button {
-  color: #5F6368;
+  color: c.mat-color(c.$foreground, icon-grey);
 }

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.scss
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.scss
@@ -13,3 +13,7 @@
   display: inline-block;
   color: c.mat-color(c.$foreground, text-light);
 }
+
+.copy_button {
+  color: #5F6368;
+}

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ts
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ts
@@ -12,4 +12,5 @@ export class Timestamp {
   @Input() date?: Date;
   @Input() completeFormat: boolean = false;
   @Input() tooltipEnabled: boolean = true;
+  timezone: string = 'UTC'
 }

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ts
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ts
@@ -12,5 +12,5 @@ export class Timestamp {
   @Input() date?: Date;
   @Input() completeFormat: boolean = false;
   @Input() tooltipEnabled: boolean = true;
-  timezone: string = 'UTC'
+  readonly timezone: string = 'UTC';
 }

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ts
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp.ts
@@ -10,6 +10,6 @@ import {Component, Input} from '@angular/core';
 })
 export class Timestamp {
   @Input() date?: Date;
-  @Input() absoluteOnly: boolean = false;
+  @Input() completeFormat: boolean = false;
   @Input() tooltipEnabled: boolean = true;
 }

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp_test.ts
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp_test.ts
@@ -4,6 +4,7 @@ import {initTestEnvironment} from '@app/testing';
 
 import {TimestampModule} from './module';
 import {Timestamp} from './timestamp';
+import {By} from '@angular/platform-browser';
 
 initTestEnvironment();
 
@@ -35,6 +36,12 @@ describe('Timestamp Component', () => {
     expect(componentInstance).toBeTruthy();
   });
 
+  it('shows "Unknown" when no date is provided', () => {
+    const fixture = TestBed.createComponent(Timestamp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerText).toEqual('Unknown');
+  });
+
   it('only shows short timestamp by default', () => {
     const fixture = TestBed.createComponent(Timestamp);
     const componentInstance = fixture.componentInstance;
@@ -53,6 +60,7 @@ describe('Timestamp Component', () => {
     componentInstance.date = date;
     componentInstance.completeFormat = true;
     fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('2020-07-01 12:50:00 UTC 10 minutes ago content_copy');
+    expect(fixture.debugElement.query(By.css('.timestamp')).nativeElement.innerText)
+      .toEqual('2020-07-01 12:50:00 UTC 10 minutes ago content_copy');
   });
 });

--- a/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp_test.ts
+++ b/grr/server/grr_response_server/gui/ui/components/timestamp/timestamp_test.ts
@@ -4,14 +4,10 @@ import {initTestEnvironment} from '@app/testing';
 
 import {TimestampModule} from './module';
 import {Timestamp} from './timestamp';
-import {DatePipe} from '@angular/common';
-import {notDeepEqual} from 'assert';
-import {DateTime} from 'luxon';
 
 initTestEnvironment();
 
 describe('Timestamp Component', () => {
-  const ABSOLUTE_FORMAT: string = "MMM d \''yy 'at' HH:mm";
 
   beforeEach(async(() => {
     TestBed
@@ -39,166 +35,24 @@ describe('Timestamp Component', () => {
     expect(componentInstance).toBeTruthy();
   });
 
-  it('shows "Just now" for dates less than 30 seconds ago', () => {
+  it('only shows short timestamp by default', () => {
     const fixture = TestBed.createComponent(Timestamp);
     const componentInstance = fixture.componentInstance;
-    const JUST_NOW = 'Just now';
 
-    componentInstance.date = new Date('2020-07-01T12:59:59');
+    const date = new Date('2020-07-01T12:59:59');
+    componentInstance.date = date;
     fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual(JUST_NOW);
-
-    componentInstance.date = new Date('2020-07-01T12:59:45');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual(JUST_NOW);
-
-    componentInstance.date = new Date('2020-07-01T12:59:30.001');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual(JUST_NOW);
-
-    componentInstance.date = new Date('2020-07-01T12:59:30.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).not.toEqual(JUST_NOW);
+    expect(fixture.nativeElement.innerText).toEqual('2020-07-01 12:59:59 UTC');
   });
 
-  it('shows "X seconds ago" for dates between 30s and 1min ago', () => {
-    const fixture = TestBed.createComponent(Timestamp);
-    const componentInstance = fixture.componentInstance;
-    const JUST_NOW = 'Just now';
-
-    componentInstance.date = new Date('2020-07-01T12:59:30.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('30 seconds ago');
-
-    componentInstance.date = new Date('2020-07-01T12:59:15');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('45 seconds ago');
-
-    componentInstance.date = new Date('2020-07-01T12:59:00.001');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('59 seconds ago');
-
-    componentInstance.date = new Date('2020-07-01T12:59:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).not.toEqual('59 seconds ago');
-    expect(fixture.nativeElement.innerText).not.toEqual('60 seconds ago');
-  });
-
-  it('shows "Xmin ago" for dates between 1 minute and 1 hour ago', () => {
+  it('shows long timestamp when completeFormat parameter is set to true', () => {
     const fixture = TestBed.createComponent(Timestamp);
     const componentInstance = fixture.componentInstance;
 
-    componentInstance.date = new Date('2020-07-01T12:59:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('1min ago');
-
-    componentInstance.date = new Date('2020-07-01T12:29:30.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('30min ago');
-
-    componentInstance.date = new Date('2020-07-01T12:00:01.001');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('59min ago');
-
-    componentInstance.date = new Date('2020-07-01T12:00:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).not.toEqual('59min ago');
-    expect(fixture.nativeElement.innerText).not.toEqual('60min ago');
-  });
-
-  it('shows "XhYmin ago" for dates between 1 hour than 24 hours ago', () => {
-    const fixture = TestBed.createComponent(Timestamp);
-    const componentInstance = fixture.componentInstance;
-
-    componentInstance.date = new Date('2020-07-01T12:00:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('1h0min ago');
-
-    componentInstance.date = new Date('2020-07-01T01:25:00');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('11h35min ago');
-
-    componentInstance.date = new Date('2020-06-30T13:00:00.001');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('23h59min ago');
-
-    componentInstance.date = new Date('2020-06-30T13:00:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).not.toEqual('23h59min ago');
-    expect(fixture.nativeElement.innerText).not.toEqual('24h0min ago');
-  });
-
-
-  it('shows "yesterday at HH:mm" for dates between 24 hours ago and yesterday beginning of day', () => {
-    const fixture = TestBed.createComponent(Timestamp);
-    const componentInstance = fixture.componentInstance;
-
-    componentInstance.date = new Date('2020-06-30T13:00:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('yesterday at 13:00');
-
-    componentInstance.date = new Date('2020-06-30T08:23:23.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('yesterday at 08:23');
-
-    componentInstance.date = new Date('2020-06-30T00:01:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).not.toEqual('yesterday at 00:01');
-
-    componentInstance.date = new Date('2020-06-30T00:00:00.000');
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).not.toEqual('yesterday at 00:00');
-  });
-
-  it('shows absolute timestamp for dates older than yesterday beginning of day', () => {
-    const fixture = TestBed.createComponent(Timestamp);
-    const componentInstance = fixture.componentInstance;
-
-    let date = new Date('2020-06-29T23:59:59.999');
+    const date = new Date('2020-07-01T12:50:00');
     componentInstance.date = date;
+    componentInstance.completeFormat = true;
     fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('Jun 29, 2020, 11:59 PM');
-
-    date = new Date('1620-06-20T12:59:59.999');
-    componentInstance.date = date;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('Jun 20, 1620, 12:59 PM');
-  });
-
-  it('shows absolute timestamp when absoluteOnly parameter is set', () => {
-    const fixture = TestBed.createComponent(Timestamp);
-    const componentInstance = fixture.componentInstance;
-    componentInstance.absoluteOnly = true;
-
-    // Just now
-    let date = new Date('2020-07-01T12:59:59.999');
-    componentInstance.date = date;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText)
-      .toEqual('Jul 1, 2020, 12:59 PM');
-
-    // 50 seconds ago
-    date = new Date('2020-07-01T12:59:09.999');
-    componentInstance.date = date;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('Jul 1, 2020, 12:59 PM');
-
-    // 10min ago
-    date = new Date('2020-07-01T12:50:59.999');
-    componentInstance.date = date;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('Jul 1, 2020, 12:50 PM');
-
-    // 9h10min ago
-    date = new Date('2020-07-01T03:50:59.999');
-    componentInstance.date = date;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('Jul 1, 2020, 3:50 AM');
-
-    // yesterday at 03:50
-    date = new Date('2020-06-30T03:50:59.999');
-    componentInstance.date = date;
-    fixture.detectChanges();
-    expect(fixture.nativeElement.innerText).toEqual('Jun 30, 2020, 3:50 AM');
+    expect(fixture.nativeElement.innerText).toEqual('2020-07-01 12:50:00 UTC 10 minutes ago content_copy');
   });
 });

--- a/grr/server/grr_response_server/gui/ui/material-theme.scss
+++ b/grr/server/grr_response_server/gui/ui/material-theme.scss
@@ -19,6 +19,7 @@ $_grr-foreground: (
   success: mat-color($mat-green, 700),
   danger: mat-color($mat-red, 700),
   in-progress: mat-color($mat-yellow, 700),
+  icon-grey: mat-color($mat-grey, 700),
 );
 // See https://github.com/angular/components/blob/b6358b2e32d6cbd3646411fc576e46dc55bcf512/src/material/core/theming/_palette.scss#L674
 $_grr-background: (


### PR DESCRIPTION
Added some changes to the timestamp component. Now, it shows the absolute format as a base format, and the tooltip contains a relative timestamp, showing how much time passed since then. Also, I added a long version, which doesn't show the relative timestamp in a tooltip, but inline instead. The long version also has a copy icon, for easy and fast copy.