### PR TITLE
Set disallow_missing_config_definitions as True by default for server components

### DIFF
--- a/debian/grr-server@.service
+++ b/debian/grr-server@.service
@@ -12,7 +12,7 @@ Restart=on-failure
 LimitNOFILE=65536
 Environment="MPLCONFIGDIR=/var/run/grr/tmp/%i" "PYTHON_EGG_CACHE=/var/run/grr/tmp/%i"
 ExecStartPre=/bin/mkdir -p /var/run/grr/tmp/%i
-ExecStart=/usr/bin/grr_server --component %i --disallow_missing_config_definitions -p StatsStore.process_id=%i_%m
+ExecStart=/usr/bin/grr_server --component %i -p StatsStore.process_id=%i_%m
 
 [Install]
 WantedBy=multi-user.target

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,7 +8,7 @@ set -e
 
 run_component() {
   COMPONENT=$1; shift
-  grr_server --component "${COMPONENT}" --disallow_missing_config_definitions "$@"
+  grr_server --component "${COMPONENT}" "$@"
 }
 
 initialize() {

--- a/grr/core/grr_response_core/lib/config_lib.py
+++ b/grr/core/grr_response_core/lib/config_lib.py
@@ -54,7 +54,9 @@ flags.DEFINE_bool("config_help", False, "Print help about the configuration.")
 flags.DEFINE_list("context", [], "Use these contexts for the config.")
 
 flags.DEFINE_bool("disallow_missing_config_definitions", False,
-                  "If true, we raise an error on undefined config options.")
+                  "If true, we raise an error on undefined config options. "
+                  "This flag has an effect only on clients because it is set "
+                  "as True by default for server components.")
 
 flags.DEFINE_multi_string(
     "parameter",

--- a/grr/server/grr_response_server/server_startup.py
+++ b/grr/server/grr_response_server/server_startup.py
@@ -9,6 +9,8 @@ import logging
 import os
 import platform
 
+from absl import flags
+
 import prometheus_client
 
 from grr_response_core import config
@@ -67,6 +69,10 @@ def Init():
   else:
     handler = logging.handlers.SysLogHandler()
   syslog_logger.addHandler(handler)
+
+  # The default behavior of server components is to raise errors when
+  # encountering unknown config options.
+  flags.FLAGS.disallow_missing_config_definitions = True
 
   try:
     config_lib.SetPlatformArchContext()


### PR DESCRIPTION
- Set `disallow_missing_config_definitions` flag to True for server components in `server_startup.py`
- Remove the flag from Debian and Docker deployment scripts

Please see [issue 671](https://github.com/google/grr/issues/671) for more context.