### PR TITLE
Split _GetReferenceObject function into 2 functions 

### DIFF
--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -710,7 +710,6 @@ def _GetReferenceObject(type_name: str) -> SchemaReference:
 
 def _GetArraySchema(items_type_name: str) -> ArraySchema:
   """Get the schema of an array with items of the given type."""
-
   return {
     "type": "array",
     "items": _GetReferenceObject(items_type_name),
@@ -740,12 +739,13 @@ def _GetFieldSchema(
   # OpenAPI Specification. See this GitHub issue [1] for more details.
   #
   # [1]: github.com/google/grr/issues/822
+  type_name = _GetTypeName(field_descriptor)
   containing_oneof: OneofDescriptor = field_descriptor.containing_oneof
   if containing_oneof is None:
     if field_descriptor.label == protobuf2.LABEL_REPEATED:
-      return _GetArraySchema(_GetTypeName(field_descriptor))
+      return _GetArraySchema(type_name)
 
-    return _GetReferenceObject(_GetTypeName(field_descriptor))
+    return _GetReferenceObject(type_name)
 
   # The following `allOf` is required to display the description by
   # documentation generation tools because the OAS specifies that there
@@ -763,11 +763,11 @@ def _GetFieldSchema(
   )
   if field_descriptor.label == protobuf2.LABEL_REPEATED:
     oneof_member["allOf"] = [
-      _GetArraySchema(_GetTypeName(field_descriptor)),
+      _GetArraySchema(type_name),
     ]
   else:
     oneof_member["allOf"] = [
-      _GetReferenceObject(_GetTypeName(field_descriptor)),
+      _GetReferenceObject(type_name),
     ]
 
   return oneof_member

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -704,7 +704,7 @@ def _GetReferenceObject(type_name: str) -> SchemaReference:
     schema definition of the selected type.
   """
   return {
-    "$ref": f"#/components/schemas/{type_name}"
+    "$ref": f"#/components/schemas/{type_name}",
   }
 
 
@@ -713,7 +713,7 @@ def _GetArraySchema(items_type_name: str) -> ArraySchema:
 
   return {
     "type": "array",
-    "items": _GetReferenceObject(items_type_name)
+    "items": _GetReferenceObject(items_type_name),
   }
 
 
@@ -763,11 +763,11 @@ def _GetFieldSchema(
   )
   if field_descriptor.label == protobuf2.LABEL_REPEATED:
     oneof_member["allOf"] = [
-      _GetArraySchema(_GetTypeName(field_descriptor))
+      _GetArraySchema(_GetTypeName(field_descriptor)),
     ]
   else:
     oneof_member["allOf"] = [
-      _GetReferenceObject(_GetTypeName(field_descriptor))
+      _GetReferenceObject(_GetTypeName(field_descriptor)),
     ]
 
   return oneof_member


### PR DESCRIPTION
Split the functionality of `_GetReferenceObject` by introducing a new function: `_GetArraySchema`.

This approach removes the `boolean` flag previously used by `_GetReferenceObject`, better separates concerns of the functions and helps remove type ambiguity.