### PR TITLE
Implement OpenAPI description generation for Protobuf maps

### DIFF
--- a/grr/proto/grr_response_proto/tests.proto
+++ b/grr/proto/grr_response_proto/tests.proto
@@ -210,3 +210,7 @@ message MetadataOneofMessage {
   }
   optional int64 field_int64 = 3;
 }
+
+message MetadataMapMessage {
+  map<sfixed64, MetadataSimpleMessage> field_map = 1;
+}

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -34,6 +34,7 @@ DescribedSchema = Dict[str,
                        Union[str, List[SchemaReference], List[ArraySchema]]]
 Schema = Union[PrimitiveSchema, EnumSchema, MessageSchema, ArraySchema]
 PrimitiveDescription = Dict[str, Union[str, PrimitiveSchema]]
+TypeHinter = Union[Descriptor, FieldDescriptor, EnumDescriptor, Type, int, str]
 
 # Follows the proto3 JSON encoding [1] as a base, but whenever
 # the OpenAPI Specification [2] provides a more specific description of the
@@ -334,9 +335,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
 
   def _CreateSchema(
       self,
-      cls: Optional[
-        Union[Descriptor, FieldDescriptor, EnumDescriptor, Type, int, str]
-      ],
+      cls: Optional[TypeHinter],
       visiting: Set[str],
   ) -> None:
     """Create OpenAPI schema from any valid type descriptor or identifier."""
@@ -828,11 +827,7 @@ def _GetPathArgsFromPath(path: str) -> List[str]:
   return path_args
 
 
-def _GetTypeName(
-    cls: Optional[
-      Union[Descriptor, FieldDescriptor, EnumDescriptor, Type, int, str]
-    ],
-) -> str:
+def _GetTypeName(cls: Optional[TypeHinter]) -> str:
   """Extract type name from protobuf `Descriptor`/`type`/`int`/`str`."""
   if isinstance(cls, FieldDescriptor):
     if _IsMapField(cls):

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -301,9 +301,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     type_name: str = _GetTypeName(field_descriptor)
     visiting.add(type_name)
 
-    key_field_d, value_field_d = (
-      _GetMapFieldKeyValueTypes(field_descriptor)
-    )
+    key_field_d, value_field_d = _GetMapFieldKeyValueTypes(field_descriptor)
 
     # pylint: disable=line-too-long
     # `protobuf.map` key types can be only a subset of the primitive types [1],

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -439,7 +439,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
 
     type_name = _GetTypeName(field_descriptor)
     containing_oneof: OneofDescriptor = field_descriptor.containing_oneof
-    description: str = ""
+    description = ""
     array_schema = None
     reference_obj = None
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -249,12 +249,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     # Create schemas for the fields' types.
     for field_descriptor in descriptor.fields:
       field_name = field_descriptor.name
-      message_descriptor = field_descriptor.message_type  # None if not Message.
-      enum_descriptor = field_descriptor.enum_type  # None if not Enum.
-      descriptor = message_descriptor or enum_descriptor
-
-      if descriptor:
-        self._CreateSchema(descriptor, visiting)
+      self._CreateSchema(field_descriptor, visiting)
 
       properties[field_name] = _GetFieldSchema(field_descriptor)
 
@@ -318,7 +313,6 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       "type": "object",
       "additionalProperties": _GetReferenceObject(_GetTypeName(value_field_d)),
     }
-
 
   def _CreateSchema(
       self,
@@ -434,10 +428,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     properties: Dict[str, Union[ArraySchema, SchemaReference]] = dict()
     for field_d in body_params:
       field_name = field_d.name
-      if field_d.label == protobuf2.LABEL_REPEATED:
-        properties[field_name] = _GetArraySchema(_GetTypeName(field_d))
-      else:
-        properties[field_name] = _GetReferenceObject(_GetTypeName(field_d))
+      properties[field_name] = _GetFieldSchema(field_d)
 
     return {
       "content": {

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -413,9 +413,9 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
         target field.
 
     Returns:
-      If the field is not part of a `protobuf.oneof`, then a simple `Reference
-      Object`, else, a dictionary that includes a description entry along the
-      `Reference Object`.
+      If the schema of the field does not require any description to explain the
+      semantics, then a normal schema or reference, else, a dictionary that
+      includes a `description` entry along the `Reference Object` or schema.
     """
     type_name = _GetTypeName(field_descriptor)
     containing_oneof: OneofDescriptor = field_descriptor.containing_oneof

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -164,9 +164,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
   def _AddPrimitiveTypesSchemas(self) -> None:
     """Adds the OpenAPI schemas for protobuf primitives and `BinaryStream`."""
     if self.schema_objs is None:  # Check required by mypy.
-      raise AssertionError(
-        "The container of OpenAPI type schemas is not initialized."
-      )
+      raise AssertionError("OpenAPI type schemas not initialized.")
 
     primitive_types_schemas = {
       primitive_type["name"]: primitive_type["schema"]
@@ -197,9 +195,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       Nothing, the schema is stored in `self.schema_objs`.
     """
     if self.schema_objs is None:  # Check required by mypy.
-      raise AssertionError(
-        "The container of OpenAPI type schemas is not initialized."
-      )
+      raise AssertionError("OpenAPI type schemas not initialized.")
 
     enum_schema_obj: EnumSchema = {
       "type": "string",
@@ -238,9 +234,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       Nothing, the schema is stored in `self.schema_objs`.
     """
     if self.schema_objs is None:  # Check required by mypy.
-      raise AssertionError(
-        "The container of OpenAPI type schemas is not initialized."
-      )
+      raise AssertionError("OpenAPI type schemas not initialized.")
 
     type_name = _GetTypeName(descriptor)
 
@@ -292,9 +286,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       Nothing, the schema is stored in `self.schema_objs`.
     """
     if self.schema_objs is None:  # Check required by mypy.
-      raise AssertionError(
-        "The container of OpenAPI type schemas is not initialized."
-      )
+      raise AssertionError("OpenAPI type schemas not initialized.")
 
     if field_descriptor is None:  # Check required by mypy.
       raise AssertionError(f"`field_descriptor` is None.")
@@ -341,9 +333,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
   ) -> None:
     """Create OpenAPI schema from any valid type descriptor or identifier."""
     if self.schema_objs is None:  # Check required by mypy.
-      raise AssertionError(
-        "The container of OpenAPI type schemas is not initialized."
-      )
+      raise AssertionError("OpenAPI type schemas not initialized.")
 
     if cls is None:
       raise ValueError(f"Trying to extract schema of None.")
@@ -433,9 +423,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       includes a `description` entry along the `Reference Object` or schema.
     """
     if self.schema_objs is None:  # Check required by mypy.
-      raise AssertionError(
-        "The container of OpenAPI type schemas is not initialized."
-      )
+      raise AssertionError("OpenAPI type schemas not initialized.")
 
     type_name = _GetTypeName(field_descriptor)
     containing_oneof: OneofDescriptor = field_descriptor.containing_oneof
@@ -650,9 +638,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     """Create the `Components Object` that holds all schema definitions."""
     self._CreateSchemas()
     if self.schema_objs is None:  # Check required by mypy.
-      raise AssertionError(
-        "The container of OpenAPI type schemas is not initialized."
-      )
+      raise AssertionError("OpenAPI type schemas not initialized.")
 
     # The `Components Object` `components` field of the root `OpenAPI Object`.
     return {

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -935,7 +935,7 @@ def _GetMapFieldKeyValueTypes(
       entry_descriptor.fields[1].name == "value"
   ):
     return KeyValueDescriptor(
-      entry_descriptor.fields[0], entry_descriptor.fields[1]
+      key=entry_descriptor.fields[0], value=entry_descriptor.fields[1]
     )
 
   if (
@@ -943,7 +943,7 @@ def _GetMapFieldKeyValueTypes(
       entry_descriptor.fields[1].name == "key"
   ):
     return KeyValueDescriptor(
-      entry_descriptor.fields[1], entry_descriptor.fields[0]
+      key=entry_descriptor.fields[1], value=entry_descriptor.fields[0]
     )
 
   return None

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -321,15 +321,16 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
 
     visiting.remove(type_name)
 
+    key_type_name = _GetTypeName(key_field_d)
+    value_type_name = _GetTypeName(value_field_d)
+
     self.schema_objs[type_name] = cast(
       Dict[str, Union[str, SchemaReference]],
       {
-        "description": f"This is a map with real key type="
-                       f"\"{_GetTypeName(key_field_d)}\" and value type="
-                       f"\"{_GetTypeName(value_field_d)}\"",
+        "description": f"This is a map with real key type=\"{key_type_name}\" "
+                       f"and value type=\"{value_type_name}\"",
         "type": "object",
-        "additionalProperties": _GetReferenceObject(
-          _GetTypeName(value_field_d)),
+        "additionalProperties": _GetReferenceObject(value_type_name),
       }
     )
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -923,8 +923,8 @@ def _GetMapFieldKeyValueTypes(
 
   Args:
     field_descriptor: The protobuf `FieldDescriptor` whose type is checked if it
-    is a map and whose type's associated `key` and `value` `FieldDescriptor`s
-    are returned.
+      is a map and whose type's associated `key` and `value` `FieldDescriptor`s
+      are returned.
 
   Returns:
     A tuple consisting of the `key` and `value` `FieldDescriptor`s (in this

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -295,6 +295,8 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     visiting.add(type_name)
 
     key_field_d, value_field_d = _GetMapFieldKeyValueTypes(field_descriptor)
+    key_type_name = _GetTypeName(key_field_d)
+    value_type_name = _GetTypeName(value_field_d)
 
     # pylint: disable=line-too-long
     # `protobuf.map` key types can be only a subset of the primitive types [1],
@@ -312,9 +314,6 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       )
 
     visiting.remove(type_name)
-
-    key_type_name = _GetTypeName(key_field_d)
-    value_type_name = _GetTypeName(value_field_d)
 
     self.schema_objs[type_name] = cast(
       Dict[str, Union[str, SchemaReference]],
@@ -822,12 +821,11 @@ def _GetTypeName(cls: Optional[TypeHinter]) -> str:
       if map_type_name.endswith("Entry"):
         map_type_name = map_type_name[:-5]
 
-      key_type_d, value_type_d = _GetMapFieldKeyValueTypes(cls)
+      key_field_d, value_field_d = _GetMapFieldKeyValueTypes(cls)
+      key_type_name = _GetTypeName(key_field_d)
+      value_type_name = _GetTypeName(value_field_d)
 
-      return (
-        f"{map_type_name}Map_"
-        f"{_GetTypeName(key_type_d)}:{_GetTypeName(value_type_d)}"
-      )
+      return f"{map_type_name}Map_{key_type_name}:{value_type_name}"
 
     if cls.message_type:
       return _GetTypeName(cls.message_type)

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -249,8 +249,8 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     # Create schemas for the fields' types.
     for field_descriptor in descriptor.fields:
       field_name = field_descriptor.name
-      message_descriptor = field_descriptor.message_type # None if not Message.
-      enum_descriptor = field_descriptor.enum_type # None if not Enum.
+      message_descriptor = field_descriptor.message_type  # None if not Message.
+      enum_descriptor = field_descriptor.enum_type  # None if not Enum.
       descriptor = message_descriptor or enum_descriptor
 
       if descriptor:
@@ -563,7 +563,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
         "default": self._GetResponseObjectDefault(router_method.name),
       },
     }
-    if body_params: # Only POST methods should have an associated `requestBody`.
+    if body_params:  # Only POST methods should have an associated `requestBody`.
       operation_obj["requestBody"] = self._GetRequestBody(body_params)
 
     return operation_obj

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -923,10 +923,11 @@ def _GetMapFieldKeyValueTypes(
 
   Args:
     field_descriptor: The protobuf `FieldDescriptor` whose type is checked if it
-    is a map and whose key and value types constants are returned.
+    is a map and whose type's associated `key` and `value` `FieldDescriptor`s
+    are returned.
 
   Returns:
-    A pair consisting of the `key` and `value` `FieldDescriptor`s (in this
+    A tuple consisting of the `key` and `value` `FieldDescriptor`s (in this
     order) extracted from the given `FieldDescriptor`'s map entry message type,
     or (None, None) if the given `FieldDescriptor` does not describe a map
     field.

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -880,9 +880,7 @@ def _GetArraySchema(items_type_name: str) -> ArraySchema:
 
 def _GetMapEntryTypeName(field_name: str) -> str:
   """Extract the name of the associated map type from a field's name."""
-  capitalized_name_components = [
-    comp.capitalize() for comp in field_name.split("_")
-  ]
+  capitalized_name_components = map(str.capitalize, field_name.split("_"))
 
   return f"{''.join(capitalized_name_components)}Entry"
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 # Lint as: python3
 """A module with API methods related to the GRR metadata."""
-# TODO 1: Scrie cod in `_GetFieldSchema` (cred) astfel incat sa se insereze in
-# descrierea OpenAPI generata pe descrierea corecta pentru map-uri. In momentul
-# de fata se descrie un array de cu itemii avand descrierea corecta a map-ului,
-# in loc sa se descrie direct map-ul.
-# TODO 2: Adauga test care verifica POST pentru metoda 7, cea cu `protobuf.oneof`
 import json
 import inspect
 import collections
@@ -280,7 +275,10 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     OpenAPI Specification allows only maps with strings as keys, so, as a
     workaround, we state the actual key type in the `description` fields of the
     **schemas of the properties/parameters** that use this type (in order to be
-    displayed by documentation generation tools).
+    displayed by documentation generation tools, see `_GetDescribedSchema`).
+    A `description` field is also added by this method in the schema definition
+    which will be added to the `Components Object` of the root `OpenAPI Object`
+    for more clarity when reading the generated description of the components.
 
     Args:
       field_descriptor: The protobuf `FieldDescriptor` associated with a

--- a/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
@@ -65,6 +65,13 @@ class MetadataOneofMessage(rdf_structs.RDFProtoStruct):
   ]
 
 
+class MetadataMapMessage(rdf_structs.RDFProtoStruct):
+  protobuf = tests_pb2.MetadataMapMessage
+  rdf_deps = [
+    "FieldMapEntry",
+  ]
+
+
 class MetadataDummyApiCallRouter(api_call_router.ApiCallRouter):
   """Dummy `ApiCallRouter` implementation used for Metadata testing."""
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
@@ -116,8 +116,16 @@ class MetadataDummyApiCallRouter(api_call_router.ApiCallRouter):
   @api_call_router.ArgsType(MetadataOneofMessage)
   @api_call_router.ResultType(MetadataOneofMessage)
   @api_call_router.Http("GET", "/metadata_test/method7")
+  @api_call_router.Http("POST", "/metadata_test/method7")
   def Method7ProtobufOneof(self, args, token=None):
     """Method 7 description."""
+
+  @api_call_router.ArgsType(MetadataMapMessage)
+  @api_call_router.ResultType(MetadataMapMessage)
+  @api_call_router.Http("GET", "/metadata_test/method8")
+  @api_call_router.Http("POST", "/metadata_test/method8")
+  def Method8ProtobufMap(self, args, token=None):
+    """Method 8 description."""
 
 
 class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
@@ -142,6 +150,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       "Method5EnumField",
       "Method6TypeReferences",
       "Method7ProtobufOneof",
+      "Method8ProtobufMap",
     }
     extracted_methods = {method.name for method in self.router_methods.values()}
 
@@ -172,6 +181,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
         "/metadata_test/method5",
         "/metadata_test/method6",
         "/metadata_test/method7",
+        "/metadata_test/method8",
       },
       openapi_paths_dict.keys()
     )
@@ -202,8 +212,12 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       openapi_paths_dict["/metadata_test/method6"].keys()
     )
     self.assertCountEqual(
-      {"get"},
+      {"get", "post"},
       openapi_paths_dict["/metadata_test/method7"].keys()
+    )
+    self.assertCountEqual(
+      {"get", "post"},
+      openapi_paths_dict["/metadata_test/method8"].keys()
     )
 
   def testRouteArgsAreCorrectlySeparated(self):
@@ -876,7 +890,50 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       self._GetParamSchema("/metadata_test/method7", "get", "oneof_simplemsg")
     )
 
+    # Check the description of the `protobuf.oneof` from the `requestBody` field
+    # of the `Operation Object` associated with `POST /metadata-test/method7`.
+    # Check the `oneof_int64` inner field of the `metadata_oneof`.
+    self.assertEqual(
+      {
+        "description": "This field is part of the \"metadata_oneof\" oneof. "
+                       "Only one field per oneof should be present.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/protobuf2.TYPE_INT64",
+          },
+        ],
+      },
+      self._GetParamSchema("/metadata_test/method7", "post", "oneof_int64")
+    )
+    # Check the `oneof_simplemsg` inner field of the `metadata_oneof`.
+    self.assertEqual(
+      {
+        "description": "This field is part of the \"metadata_oneof\" oneof. "
+                       "Only one field per oneof should be present.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/grr.MetadataSimpleMessage",
+          },
+        ],
+      },
+      self._GetParamSchema("/metadata_test/method7", "post", "oneof_simplemsg")
+    )
+
   def _GetParamSchema(self, method_path, http_method, param_name):
+    if http_method == "post":
+      return (
+        self.openapi_desc_dict
+          .get("paths")
+          .get(method_path)
+          .get(http_method)
+          .get("requestBody")
+          .get("content")
+          .get("application/json")
+          .get("schema")
+          .get("properties")
+          .get(param_name)
+      )
+
     params = (
       self.openapi_desc_dict
         .get("paths")


### PR DESCRIPTION
In this PR I introduce OpenAPI description generation for `protobuf.map` types, as well as a test that verifies the generated output. 

There is a difference between `protobuf.map` and the OpenAPI Specification descriptions of maps: `protobuf.map`s support ["any integral or string type" for the keys' type](https://developers.google.com/protocol-buffers/docs/proto#maps), whereas the OpenAPI Specification allows only [`string` for the keys' type](https://swagger.io/docs/specification/data-models/dictionaries/).

In order to let users know the actual type of the keys, I use the same approach as in the case of [`protobuf.oneof` semantics](https://github.com/google/grr/pull/827), which is to specify the actual types in a comment stored in the `description` field of the `schema` dictionary used to describe route parameters and composite types' properties, as well as in the `description` field of the actual schema of the map type. 
The parameter/properties `description`s are rendered by documentation generation tools such as [ReDoc](https://github.com/Redocly/redoc) , whereas the `description` field of the map type schema (from the `components` field of the root `OpenAPI Object`) can be helpful when reading the generated JSON as is, for debugging purposes.

Please note that I use the ":thumbsup:" emoji to keep track of comments that I've addressed in a yet to be committed/pushed commit.