### PR TITLE
Detect optional path arguments in GRR API routes and present them in the OpenAPI description

### DIFF
--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1081,7 +1081,7 @@ def _GroupRoutesByStem(
 
 def _GetGroupedRoutes(routes: List[List[str]]) -> List[RouteInfo]:
   comps_trie_root = _CreateTrie(routes)
-  grouped_routes_stems = dict()
+  grouped_routes_stems: Dict[str, Dict[str, List[ComponentTrieNode]]] = dict()
   _GroupRoutesByStem(comps_trie_root, [], None, grouped_routes_stems)
 
   grouped_routes = []

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1007,7 +1007,11 @@ def _IsMapField(field_descriptor: FieldDescriptor) -> bool:
 
 
 class ComponentTrieNode:
-  def __init__(self, component, parent_path):
+  def __init__(
+      self,
+      component: str,
+      parent_path: str,
+  ) -> None:
     self.component = component
     if parent_path:
       self.path = f"{parent_path}/{component}"
@@ -1015,7 +1019,7 @@ class ComponentTrieNode:
       self.path = component
     self.is_path_arg = component.startswith("<") and component.endswith(">")
     self.is_route_end = False
-    self.children = dict()
+    self.children: Dict[str, ComponentTrieNode] = dict()
 
 
 def _CreateTrie(routes: Iterable[Iterable[str]]) -> ComponentTrieNode:

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1080,6 +1080,24 @@ def _GroupRoutesByStem(
 
 
 def _GetGroupedRoutes(routes: List[List[str]]) -> List[RouteInfo]:
+  """Get a list of routes and their required and optional path arguments.
+
+  This function creates a trie of the path components from the given list of
+  routes and then identifies groups of routes that can be reduced to a single
+  route that has optional path arguments.
+
+  Args:
+    routes: A list of routes where each route is represented as a list where
+      the first element is a string representing the HTTP method of the route
+      and the following elements are strings representing the path components.
+
+  Returns:
+    A list of `RouteInfo`s which are tuples consisting of three elements: a list
+    with the HTTP method and the components of the largest path that covers
+    multiple of the initial routes given as argument, a list of path components
+    which represent the required path arguments and a list of path components
+    which represent the optional path arguments.
+  """
   comps_trie_root = _CreateTrie(routes)
   grouped_routes_stems: Dict[str, Dict[str, List[ComponentTrieNode]]] = dict()
   _GroupRoutesByStem(comps_trie_root, [], None, grouped_routes_stems)

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -7,7 +7,8 @@ import collections
 
 from urllib import parse as urlparse
 from typing import Optional, cast
-from typing import Type, Any, Union, Tuple, List, Set, Dict, DefaultDict
+from typing import Type, Any, Union, Tuple, Iterable, List, Set
+from typing import Dict, DefaultDict
 from typing import NamedTuple
 
 from google.protobuf.descriptor import Descriptor
@@ -497,9 +498,9 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
 
   def _GetParameters(
       self,
-      required_path_params: List[FieldDescriptor],
-      optional_path_params: List[FieldDescriptor],
-      query_params: List[FieldDescriptor],
+      required_path_params: Iterable[FieldDescriptor],
+      optional_path_params: Iterable[FieldDescriptor],
+      query_params: Iterable[FieldDescriptor],
   ) -> List[
     Dict[str, Union[str, bool, SchemaReference, ArraySchema]]
   ]:
@@ -527,7 +528,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
 
   def _GetRequestBody(
       self,
-      body_params: List[FieldDescriptor],
+      body_params: Iterable[FieldDescriptor],
   ) -> Dict[str, Dict]:
     """Create the OpenAPI description of the request body of a route."""
     if not body_params:
@@ -697,10 +698,10 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       http_method: str,
       path: str,
       router_method: Any,
-      required_path_params: List[FieldDescriptor],
-      optional_path_params: List[FieldDescriptor],
-      query_params: List[FieldDescriptor],
-      body_params: List[FieldDescriptor],
+      required_path_params: Iterable[FieldDescriptor],
+      optional_path_params: Iterable[FieldDescriptor],
+      query_params: Iterable[FieldDescriptor],
+      body_params: Iterable[FieldDescriptor],
   ) -> Dict[str, Any]:
     """Create the OpenAPI `Operation Object` associated with the given args."""
 
@@ -1017,7 +1018,7 @@ class ComponentTrieNode:
     self.children = dict()
 
 
-def _CreateTrie(routes: List[List[str]]) -> ComponentTrieNode:
+def _CreateTrie(routes: Iterable[Iterable[str]]) -> ComponentTrieNode:
   """Creates a trie of routes components and returns the root of the trie."""
   root = ComponentTrieNode("", "")
 
@@ -1079,7 +1080,7 @@ def _GroupRoutesByStem(
     path_args.pop()
 
 
-def _GetGroupedRoutes(routes: List[List[str]]) -> List[RouteInfo]:
+def _GetGroupedRoutes(routes: Iterable[Iterable[str]]) -> List[RouteInfo]:
   """Get a list of routes and their required and optional path arguments.
 
   This function creates a trie of the path components from the given list of
@@ -1099,7 +1100,9 @@ def _GetGroupedRoutes(routes: List[List[str]]) -> List[RouteInfo]:
     which represent the optional path arguments.
   """
   comps_trie_root = _CreateTrie(routes)
-  grouped_routes_stems: Dict[str, Dict[str, List[ComponentTrieNode]]] = dict()
+  grouped_routes_stems: Dict[str, Dict[str, Iterable[ComponentTrieNode]]] = (
+    dict()
+  )
   _GroupRoutesByStem(comps_trie_root, [], None, grouped_routes_stems)
 
   grouped_routes = []

--- a/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
@@ -1026,8 +1026,206 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       self._GetParamSchema("/metadata_test/method8", "post", "field_map")
     )
 
+  def testOptionalPathParamsAreCorrectlyDescribedInOpenApiDescription(self):
+    # This test verifies that path arguments are marked correctly as optional or
+    # required.
+    # The fact that the API routes that point out optional path arguments are
+    # grouped under the same route described in the OpenAPI description is
+    # tested by `testAllRoutesAreInOpenApiDescription`.
+
+    # Test `GET /metadata_test/method9/{metadata_id}` parameters.
+    self.assertCountEqual(
+      [
+        {
+          "name": "metadata_id",
+          "in": "path",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_STRING",
+          },
+        },
+        {
+          "name": "metadata_arg1",
+          "in": "query",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_INT64",
+          },
+        },
+        {
+          "name": "metadata_arg2",
+          "in": "query",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_BOOL",
+          },
+        },
+      ],
+      [
+        self._GetParamDescription("/metadata_test/method9/{metadata_id}", "get",
+                                  "metadata_id"),
+        self._GetParamDescription("/metadata_test/method9/{metadata_id}", "get",
+                                  "metadata_arg1"),
+        self._GetParamDescription("/metadata_test/method9/{metadata_id}", "get",
+                                  "metadata_arg2"),
+      ]
+    )
+
+    # Test `GET /metadata_test/method9/{metadata_id}/fixed1/{metadata_arg1}`
+    # parameters.
+    self.assertCountEqual(
+      [
+        {
+          "name": "metadata_id",
+          "in": "path",
+          "required": True,
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_STRING",
+          },
+        },
+        {
+          "name": "metadata_arg1",
+          "in": "path",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_INT64",
+          },
+        },
+        {
+          "name": "metadata_arg2",
+          "in": "query",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_BOOL",
+          },
+        },
+      ],
+      [
+        self._GetParamDescription(
+          "/metadata_test/method9/{metadata_id}/fixed1/{metadata_arg1}",
+          "get",
+          "metadata_id"
+        ),
+        self._GetParamDescription(
+          "/metadata_test/method9/{metadata_id}/fixed1/{metadata_arg1}",
+          "get",
+          "metadata_arg1"
+        ),
+        self._GetParamDescription(
+          "/metadata_test/method9/{metadata_id}/fixed1/{metadata_arg1}",
+          "get",
+          "metadata_arg2"
+        ),
+      ]
+    )
+
+    # Test
+    # `GET /metadata_test/method9/{metadata_id}/{metadata_arg1}/{metadata_arg2}`
+    # parameters.
+    self.assertCountEqual(
+      [
+        {
+          "name": "metadata_id",
+          "in": "path",
+          "required": True,
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_STRING",
+          },
+        },
+        {
+          "name": "metadata_arg1",
+          "in": "path",
+          "required": True,
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_INT64",
+          },
+        },
+        {
+          "name": "metadata_arg2",
+          "in": "path",
+          "required": True,
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_BOOL",
+          },
+        },
+      ],
+      [
+        self._GetParamDescription(
+          "/metadata_test"
+          "/method9/{metadata_id}/{metadata_arg1}/{metadata_arg2}",
+          "get",
+          "metadata_id"
+        ),
+        self._GetParamDescription(
+          "/metadata_test"
+          "/method9/{metadata_id}/{metadata_arg1}/{metadata_arg2}",
+          "get",
+          "metadata_arg1"
+        ),
+        self._GetParamDescription(
+          "/metadata_test"
+          "/method9/{metadata_id}/{metadata_arg1}/{metadata_arg2}",
+          "get",
+          "metadata_arg2"
+        ),
+      ]
+    )
+
+    # Test `POST /metadata_test/method9/{metadata_id}/{metadata_arg1}`
+    # parameters.
+    self.assertCountEqual(
+      [
+        {
+          "name": "metadata_id",
+          "in": "path",
+          "required": True,
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_STRING",
+          },
+        },
+        {
+          "name": "metadata_arg1",
+          "in": "path",
+          "required": True,
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_INT64",
+          },
+        },
+      ],
+      [
+        self._GetParamDescription(
+          "/metadata_test/method9/{metadata_id}/{metadata_arg1}",
+          "post",
+          "metadata_id"
+        ),
+        self._GetParamDescription(
+          "/metadata_test/method9/{metadata_id}/{metadata_arg1}",
+          "post",
+          "metadata_arg1"
+        ),
+      ]
+    )
+
+  def _GetParamDescription(self, method_path, http_method, param_name):
+    params = (
+      self.openapi_desc_dict
+        .get("paths")
+        .get(method_path)
+        .get(http_method)
+        .get("parameters")
+    )
+
+    for param in params:
+      if param["name"] == param_name:
+        return param
+
+    return None
+
   def _GetParamSchema(self, method_path, http_method, param_name):
+    param_description = self._GetParamDescription(
+      method_path, http_method, param_name
+    )
+
+    if param_description is not None:
+      return param_description["schema"]
+
     if http_method == "post":
+      # Try finding the param in the `requestBody`.
       return (
         self.openapi_desc_dict
           .get("paths")
@@ -1041,17 +1239,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
           .get(param_name)
       )
 
-    params = (
-      self.openapi_desc_dict
-        .get("paths")
-        .get(method_path)
-        .get(http_method)
-        .get("parameters")
-    )
-
-    for param in params:
-      if param["name"] == param_name:
-        return param["schema"]
+    return None
 
 
 def main(argv):

--- a/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
@@ -127,6 +127,24 @@ class MetadataDummyApiCallRouter(api_call_router.ApiCallRouter):
   def Method8ProtobufMap(self, args, token=None):
     """Method 8 description."""
 
+  @api_call_router.ArgsType(MetadataSimpleMessage)
+  @api_call_router.ResultType(MetadataSimpleMessage)
+  @api_call_router.Http("GET", "/metadata_test/method9")
+  @api_call_router.Http("GET", "/metadata_test/method9/<metadata_id>")
+  @api_call_router.Http(
+    "POST", "/metadata_test/method9/<metadata_id>/<metadata_arg1>"
+  )
+  @api_call_router.Http(
+    "GET",
+    "/metadata_test/method9/<metadata_id>/<metadata_arg1>/<metadata_arg2>"
+  )
+  @api_call_router.Http("GET", "/metadata_test/method9/<metadata_id>/fixed1")
+  @api_call_router.Http(
+    "GET", "/metadata_test/method9/<metadata_id>/fixed1/<metadata_arg1>"
+  )
+  def Method9OptionalPathArgs(self, args, token=None):
+    """Method 9 description"""
+
 
 class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
   """Test for `ApiGetOpenApiDescriptionHandler`."""
@@ -151,6 +169,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       "Method6TypeReferences",
       "Method7ProtobufOneof",
       "Method8ProtobufMap",
+      "Method9OptionalPathArgs",
     }
     extracted_methods = {method.name for method in self.router_methods.values()}
 
@@ -182,6 +201,10 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
         "/metadata_test/method6",
         "/metadata_test/method7",
         "/metadata_test/method8",
+        "/metadata_test/method9/{metadata_id}",
+        "/metadata_test/method9/{metadata_id}/{metadata_arg1}",
+        "/metadata_test/method9/{metadata_id}/{metadata_arg1}/{metadata_arg2}",
+        "/metadata_test/method9/{metadata_id}/fixed1/{metadata_arg1}",
       },
       openapi_paths_dict.keys()
     )
@@ -218,6 +241,27 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
     self.assertCountEqual(
       {"get", "post"},
       openapi_paths_dict["/metadata_test/method8"].keys()
+    )
+    self.assertCountEqual(
+      {"get"},
+      openapi_paths_dict["/metadata_test/method9/{metadata_id}"].keys()
+    )
+    self.assertCountEqual(
+      {"post"},
+      openapi_paths_dict
+        .get("/metadata_test/method9/{metadata_id}/{metadata_arg1}").keys()
+    )
+    self.assertCountEqual(
+      {"get"},
+      openapi_paths_dict.get(
+        "/metadata_test/method9/{metadata_id}/{metadata_arg1}/{metadata_arg2}"
+      ).keys()
+    )
+    self.assertCountEqual(
+      {"get"},
+      openapi_paths_dict.get(
+        "/metadata_test/method9/{metadata_id}/fixed1/{metadata_arg1}"
+      ).keys()
     )
 
   def testRouteArgsAreCorrectlySeparated(self):


### PR DESCRIPTION
## Introduction
In this PR I introduce code that figures out if there are multiple routes associated to a singe router method which actually just describe a single route with optional path arguments. The implementation is a bit more generic than what is currently necessary for the routes described in `api_call_router.py`, in the sense that it also treats multiple routes with different HTTP methods associated with a single router method, as well as multiple routes with the same HTTP method but different path components and different required / optional path arguments for the same router method. I implemented it this way because it covers more theoretically possible cases (but which aren't necessarily a good practice, such as using the same router method for routes with different HTTP methods) and because it allows for easier testing of the generated OpenAPI description in `metadata_test.py` (for example, there are tests that do use routes with different HTTP methods in order to avoid the overhead of creating separate router methods for minor differences).

## Implementation details
The idea behind the implementation is to create a trie of all the routes components (meaning the HTTP method and the URL components which can be "fixed" or which can represent Werkzeug path parameters) for each router method. Using this trie, we can find all the routes that share a common "stem" path and add optional path arguments in its continuation.

The main idea behind the problem of finding these compatible routes that can be reduced to one is that **sequences of consecutive terminal path args can be reduced to a single route with optional path args**. By terminal I mean that the path arg is the last component in a route associated with the router method.

In the following lines I use * after a component to note the fact that there is a route that ends with that component.

### Examples
  
  Example 1: `_prefix_/fixed*/arg1*/arg2*/arg3*` can be reduced to the stem `_prefix_/fixed*` with:
    - required path arguments = `extract_path_arguments(_prefix_`)
    - optional path arguments = [arg1, arg2, arg3].
  
  Example 2: `_prefix_/arg1*/arg2*/arg3*` can be reduced to the stem `_prefix_/arg1*` with:
    - required path arguments = `extract_path_arguments(_prefix_`) + [arg1]
    - optional path arguments = [arg2, arg3].

### Notes

Note 1: If there is a terminal component, followed by an unterminal path argument and a terminal path argument, we can't reduce them:
  ex.: `_prefix_/fixed1*_or_arg1*/arg2/arg3*` will result in 2 routes: stem `_prefix_/fixed1*_or_arg1*` and stem `_prefix_/fixed1*_or_arg1*/arg2/arg3*` and not stem `_prefix_/fixed1*_or_arg1*` with optional path args [arg2, arg3] because arg2 can only appear if arg3 appears.

Note 2: Whenever there is a terminal fixed component, a new route is defined (which may or may not have optional path arguments that follow to its right):
  ex.1: `_prefix_/fixed1*/fixed2*` will result in 2 routes: `_prefix_/fixed1*` and `_prefix_/fixed2*`
  ex.2: `_prefix_/fixed1*/arg1*/arg2*/fixed3*/arg3*` will result in 2 routes:
        - stem `_prefix_/fixed1*` with optional path args = [arg1, arg2], required path args = `extract_path_arguments(_prefix_`)
        - stem `_prefix_/fixed1/arg1/arg2/fixed3*` with optional args = [arg3], required path args = `extract_path_arguments(_prefix_`) + [arg1, arg2]



_Please note that I use the ":thumbsup:" emoji to mark comments that I've addressed in a yet to be created / pushed commit._