### PR TITLE
Add Category decorator for GetLastClientIPAddress router method

### DIFF
--- a/grr/server/grr_response_server/gui/api_call_router.py
+++ b/grr/server/grr_response_server/gui/api_call_router.py
@@ -304,6 +304,7 @@ class ApiCallRouterStub(ApiCallRouter):
 
     raise NotImplementedError()
 
+  @Category("Clients")
   @ArgsType(api_client.ApiGetLastClientIPAddressArgs)
   @ResultType(api_client.ApiGetLastClientIPAddressResult)
   @Http("GET", "/api/clients/<client_id>/last-ip")


### PR DESCRIPTION
`GetLastClientIPAddress` was the only router method missing a `@Category` decorator.