### PR TITLE
Refactor OpenAPI optional path parameters detection to use lists instead of a trie

### DIFF
--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1125,10 +1125,14 @@ def _CompareComponentsCollections(
   return 0
 
 
-class UngroupedRoute(NamedTuple):
+class UngroupedRoute:
   """A named tuple for storing routes and their state during route grouping."""
-  route: Collection[str]
+  route: List[str]
   processed: bool
+
+  def __init__(self, route: List[str] = None, processed: bool = False):
+    self.route = route
+    self.processed = processed
 
 
 def _IsExtension(
@@ -1161,7 +1165,7 @@ def _ExtractPathParamsFromRouteList(route_comps: Collection[str]) -> Set[str]:
   return path_params
 
 
-def _GetGroupedRoutes(routes: List[Collection[str]]) -> List[RouteInfo]:
+def _GetGroupedRoutes(routes: List[List[str]]) -> List[RouteInfo]:
   """Get a list of routes and their required and optional path parameters."""
   routes.sort(key=cmp_to_key(_CompareComponentsCollections))
   ungrouped_routes = [
@@ -1171,19 +1175,21 @@ def _GetGroupedRoutes(routes: List[Collection[str]]) -> List[RouteInfo]:
 
   grouped_routes = []
   for i_stem_route in range(num_routes):
-    stem_route, stem_route_processed = ungrouped_routes[i_stem_route]
+    stem_route = ungrouped_routes[i_stem_route].route
+    stem_route_processed = ungrouped_routes[i_stem_route].processed
     if stem_route_processed:
       continue
 
     parent_route = stem_route
     for i_child_route in range(i_stem_route + 1, num_routes):
-      child_route, child_route_processed = ungrouped_routes[i_child_route]
+      child_route = ungrouped_routes[i_child_route].route
+      child_route_processed = ungrouped_routes[i_child_route].processed
 
       if child_route_processed:
         continue
-      ungrouped_routes[i_child_route].processed = True
 
       if _IsExtension(child_route, parent_route):
+        ungrouped_routes[i_child_route].processed = True
         parent_route = child_route
 
     required_path_params = _ExtractPathParamsFromRouteList(stem_route)

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1039,7 +1039,7 @@ def _CompareComponentsCollections(
 
 
 class UngroupedRoute:
-  """A named tuple for storing routes and their state during route grouping."""
+  """A class for storing routes and their state during route grouping."""
   route: List[str]
   processed: bool
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1030,12 +1030,7 @@ def _CompareComponentsCollections(
     if comp_1 > comp_2:
       return 1
 
-  if len(comps_1) < len(comps_2):
-    return -1
-  if len(comps_1) > len(comps_2):
-    return 1
-
-  return 0
+  return len(comps_1) - len(comps_2)
 
 
 class UngroupedRoute:

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1130,7 +1130,7 @@ class UngroupedRoute:
   route: List[str]
   processed: bool
 
-  def __init__(self, route: List[str] = None, processed: bool = False):
+  def __init__(self, route: List[str], processed: bool):
     self.route = route
     self.processed = processed
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -4,6 +4,7 @@
 import json
 import inspect
 import collections
+import functools
 
 from urllib import parse as urlparse
 from typing import Optional, cast
@@ -12,8 +13,6 @@ from typing import Iterable, Collection
 from typing import Tuple, List, Set
 from typing import Dict, DefaultDict
 from typing import NamedTuple
-
-from functools import cmp_to_key
 
 from google.protobuf.descriptor import Descriptor
 from google.protobuf.descriptor import EnumDescriptor
@@ -1113,7 +1112,7 @@ def _GetGroupedRoutes(routes: List[List[str]]) -> List[RouteInfo]:
     A list of `RouteInfo` named tuples that hold the extracted required and
     optional path parameters for each group of routes detected.
   """
-  routes.sort(key=cmp_to_key(_CompareComponentsCollections))
+  routes.sort(key=functools.cmp_to_key(_CompareComponentsCollections))
   ungrouped_routes = [
     UngroupedRoute(route=route, processed=False) for route in routes
   ]

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -1045,19 +1045,38 @@ class UngroupedRoute:
 
 def _IsExtension(
     longer_route: List[str],
-    smaller_route: List[str],
+    shorter_route: List[str],
 ) -> bool:
+  """Verifies whether a route extends another by exactly one path parameter.
+
+  Route B is considered to extend route A iff route B has exactly one extra path
+  component, situated at the end of the route and which is a path parameter,
+  while the rest of B is equal to A (i.e. B = A + ["<path_param>"]).
+  The two routes (the stem and the candidate) are represented as lists of route
+  components, where the first element in each list is the HTTP method associated
+  with the route.
+
+  Args:
+    longer_route: A list of strings representing the components of the candidate
+      extending route.
+    shorter_route: A list of strings representing the components of the stem
+      route which might be extended by `longer_route`.
+
+  Returns:
+    A boolean representing whether `longer_route` is an extension of
+    `shorter_route` or not.
+  """
   len_longer = len(longer_route)
-  len_smaller = len(smaller_route)
+  len_shorter = len(shorter_route)
   # The longer child route is expected to have exactly one more path component.
-  if len_longer - len_smaller != 1:
+  if len_longer - len_shorter != 1:
     return False
   # And that single extra path component must be a path parameter.
   if not(longer_route[-1].startswith("<") and longer_route[-1].endswith(">")):
     return False
 
   # Verify that the rest of the components are the same.
-  for comp_longer, comp_smaller in zip(longer_route, smaller_route):
+  for comp_longer, comp_smaller in zip(longer_route, shorter_route):
     if comp_longer != comp_smaller:
       return False
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -7,7 +7,9 @@ import collections
 
 from urllib import parse as urlparse
 from typing import Optional, cast
-from typing import Type, TypeVar, Any, Union, Tuple, Iterable, List, Set
+from typing import Type, TypeVar, Any, Union
+from typing import Iterable, Collection
+from typing import Tuple, List, Set
 from typing import Dict, DefaultDict
 from typing import NamedTuple
 
@@ -1143,3 +1145,21 @@ def _GetGroupedRoutes(routes: Iterable[Iterable[str]]) -> List[RouteInfo]:
     )
 
   return grouped_routes
+
+
+def _CompareComponentsIterables(
+    comps_1: Collection[str],
+    comps_2: Collection[str],
+) -> int:
+  for comp_1, comp_2 in zip(comps_1, comps_2):
+    if comp_1 < comp_2:
+      return -1
+    if comp_1 > comp_2:
+      return 1
+
+  if len(comps_1) < len(comps_2):
+    return -1
+  if len(comps_1) > len(comps_2):
+    return 1
+
+  return 0


### PR DESCRIPTION
## Introduction
In [PR 837](https://github.com/google/grr/pull/837) I introduced the code that detects optional path parameters from the GRR API routes and describes them accordingly in the generated OpenAPI description. That implementation was based on a trie in order to represent the routes. In this PR I introduce an alternative solution that replaces the trie with lists, improving readability, but affecting the time complexity.

## How it works
The core idea is the same as in the trie-based solution: we want to find and group routes that have a common "stem" route and continue to extend it with **consecutive terminal path parameters** (e.g. `_prefix_/arg1`, `_prefix_/arg1/arg2` and `_prefix_/arg1/arg2/arg3` can be reduced to `_prefix_/arg1/arg2/arg3` with `required_args = [arg1]` and `optional_args = [arg2, arg3]`). The path parameters that are present in the stem route will be required in the final (longest) route of the detected group, while the rest of the path parameters (the ones that are not in the stem) will be optional. For more notes and examples about this idea, please see the [description of PR 837](https://github.com/google/grr/pull/837).

The way this list-based implementation works is: 

1. sort all the routes (which are represented as lists of strings representing HTTP methods and path components, such as `["GET", "fixed1", "<arg1>"]`) and mark all of them as unvisited.
2. iterate through the routes and for each route that hasn't been visited, consider it a new stem route, then:
    1. start looking to the right of the newly discovered stem route for the route that extends it.
    2. if the extending route is found, mark it as visited and continue the search for the route that extends this newly found one, to its right in the list of routes.
    3. after finding the longest route in the group of routes that extend the stem route, extract the required path parameters from the stem route, and the optional ones as the path parameters that appear in the longest route, but not in the stem route.

### Notes
1. Sorting the list of routes insures us that all the extending routes of a route are to its right in the list. This property helps us avoid grouping together groups of routes (e.g. `_prefix_/arg1/arg2`, `_prefix_/arg1/arg2/arg3` and `_prefix_/arg1` in this order would require to "merge" the groups with the stems `_prefix_/arg1/arg2` and `_prefix_/arg1`). An alternative to sorting and using this property is using a disjoint-set forest, but I believe that would make the code harder to read and the time complexity advantage is not extremely important as it doesn't change the overall complexity of the algorithm.

## Time complexity analysis
### Notations:
- N = total number of all the path components of all the routes (even components that overlap with components from other route)
- N' = total number of nodes in the generated trie
- H = the maximum number of components in a route
- R = the number of routes associated with the current router method
- L = the maximum length of a string representing a route

### Trie-based solution
The time complexity of the trie-based solution is:
- O( N = creation of the trie
    - \+ N' = "touching" all the nodes in the trie during the depth traversal
    - \+ R \* H = copying the path params of newly found routes group in lists of required and optional parameters
    - \+ R \* H = arranging the detected routes and their path parameters into `RouteInfo` named tuples (replaced by class instances in the list-based implementation) at the end of `_GetGroupedRoutes`
- )

=> O(N \+ N' \+ R \* H), but N' <= N <= R \* H <= R \* L, therefore **O(R \* L)**.

### Lists-based solution
The time complexity of the lists-based solution is:
- O( R \* logR \* L = lexicographically sorting the routes represented as lists of strings
    - \+ R \* (R \* L) = traversal of the stem routes and their possible extensions together with the checks if the candidate routes extend the stem route
    - \+ R \* H = extracting and separating the path arguments when a group of routes is found
- )

=> O(R \* logR \* L + R^2 \* L + R \* H), but R \* H <= R \* L, therefore **O(R^2 * L)**

### Notes
1. I've presented in the complexity computation only the points of interest in the code that might affect the asymptotic time complexity.
2. I didn't analyze the common parts of code, especially the code that calls the two implementations, as this comparison is strictly of the two implementations of extracting the grouped routes.

## Conclusion
The trie-based solution has a better time complexity, but it also uses an extra O(H) space complexity on stack and is harder to read. Also, the fact that the number of routes associated with a single router method is currently, and also probably in the future, very small, I believe makes the asymptotic time complexity a small factor in deciding which implementation to use, compared to readability.


Please let me know your suggestions and if you find any mistakes in the algorithm / analysis.


_Please note that I use the ":thumbsup:" emoji to mark comments that I've addressed in a yet to be created / pushed commit._