### PR TITLE
Extract type from protobuf semantic field option and use it in OpenAPI description

### DIFF
--- a/grr/proto/grr_response_proto/tests.proto
+++ b/grr/proto/grr_response_proto/tests.proto
@@ -258,7 +258,7 @@ message MetadataSemTypeMessage {
   }];
 
   oneof semtype_oneof {
-    uint64 oneof_date_time = 11 [(sem_type) = {
+    uint64 oneof_datetime = 11 [(sem_type) = {
       type: "RDFDatetime",
       description: "Oneof field with `sem_type` option."
     }];

--- a/grr/proto/grr_response_proto/tests.proto
+++ b/grr/proto/grr_response_proto/tests.proto
@@ -214,3 +214,9 @@ message MetadataOneofMessage {
 message MetadataMapMessage {
   map<sfixed64, MetadataSimpleMessage> field_map = 1;
 }
+
+message MetadataSemTypeMessage {
+  optional string field_date_time = 1 [(sem_type) = {
+    type: "RDFDatetime", description: "Simple field with `sem_type` option."
+  }];
+}

--- a/grr/proto/grr_response_proto/tests.proto
+++ b/grr/proto/grr_response_proto/tests.proto
@@ -216,7 +216,52 @@ message MetadataMapMessage {
 }
 
 message MetadataSemTypeMessage {
-  optional string field_date_time = 1 [(sem_type) = {
-    type: "RDFDatetime", description: "Simple field with `sem_type` option."
+  optional uint64 field_datetime = 1 [(sem_type) = {
+    type: "RDFDatetime",
+    description: "field_datetime with `sem_type` option."
   }];
+  optional uint64 field_datetimeseconds = 2 [(sem_type) = {
+    type: "RDFDatetimeSeconds",
+    description: "field_datetimeseconds with `sem_type` option."
+  }];
+  optional uint64 field_duration = 3 [(sem_type) = {
+    type: "Duration",
+    description: "field_duration with `sem_type` option."
+  }];
+  optional uint64 field_durationseconds = 4 [(sem_type) = {
+    type: "DurationSeconds",
+    description: "field_durationseconds with `sem_type` option."
+  }];
+  optional bytes field_rdfbytes = 5 [(sem_type) = {
+    type: "RDFBytes",
+    description: "field_rdfbytes with `sem_type` option."
+  }];
+  optional bytes field_hashdigest = 6 [(sem_type) = {
+    type: "HashDigest",
+    description: "field_hashdigest with `sem_type` option."
+  }];
+  optional string field_globexpression = 7 [(sem_type) = {
+    type: "GlobExpression",
+    description: "field_globexpression with `sem_type` option."
+  }];
+  optional uint64 field_bytesize = 8 [(sem_type) = {
+    type: "ByteSize",
+    description: "field_bytesize with `sem_type` option."
+  }];
+  optional string field_rdfurn = 9 [(sem_type) = {
+    type: "RDFURN",
+    description: "field_rdfurn with `sem_type` option."
+  }];
+  optional string field_sessionid = 10 [(sem_type) = {
+    type: "SessionID",
+    description: "field_sessionid with `sem_type` option."
+  }];
+
+  oneof semtype_oneof {
+    uint64 oneof_date_time = 11 [(sem_type) = {
+      type: "RDFDatetime",
+      description: "Oneof field with `sem_type` option."
+    }];
+    string oneof_string = 12;
+  }
 }

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -137,59 +137,49 @@ rdf_types_schemas: Dict[str, Schema] = {
   "RDFDatetime": {
     "type": "string",
     "format": "uint64",
-    "description": "RDF type is `RDFDatetime` and it represents "
-                   "the number of microseconds since epoch to a timestamp.",
+    "description": "the number of microseconds since epoch to a timestamp.",
   },
   "RDFDatetimeSeconds": {
     "type": "string",
     "format": "uint64",
-    "description": "RDF type is `RDFDatetimeSeconds` and it represents "
-                   "the number of seconds since epoch to a timestamp.",
+    "description": "the number of seconds since epoch to a timestamp.",
   },
   "Duration": {
     "type": "string",
     "format": "uint64",
-    "description": "RDF type is `Duration` and it represents "
-                   "the number of microseconds between two timestamps.",
+    "description": "the number of microseconds between two timestamps.",
   },
   "DurationSeconds": {
     "type": "string",
     "format": "uint64",
-    "description": "RDF type is `DurationSeconds` and it represents "
-                   "the number of seconds between two timestamps.",
+    "description": "the number of seconds between two timestamps.",
   },
   "RDFBytes": {
     "type": "string",
     "format": "byte",
-    "description": "RDF type is `RDFBytes` and it represents "
-                   "a buffer of bytes.",
+    "description": "a buffer of bytes.",
   },
   "HashDigest": {
     "type": "string",
     "format": "byte",
-    "description": "RDF type is `HashDigest` and it represents "
-                   "a binary hash digest with hex string representation.",
+    "description": "a binary hash digest with hex string representation.",
   },
   "GlobExpression": {
     "type": "string",
-    "description": "RDF type is `GlobExpression` and it represents "
-                   "a glob expression for a client path.",
+    "description": "a glob expression for a client path.",
   },
   "ByteSize": {
     "type": "string",
     "format": "uint64",
-    "description": "RDF type is `ByteSize` and it represents "
-                   "a size for bytes allowing standard unit prefixes.",
+    "description": "a size for bytes allowing standard unit prefixes.",
   },
   "RDFURN": {
     "type": "string",
-    "description": "RDF type is `RDFURN` and it represents "
-                   "an object to abstract URL manipulation.",
+    "description": "an object to abstract URL manipulation.",
   },
   "SessionID": {
     "type": "string",
-    "description": "RDF type is `SessionID` and it represents "
-                   "an rdfvalue object that represents a session_id.",
+    "description": "an rdfvalue object that represents a session_id.",
   },
 }
 
@@ -262,6 +252,15 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     """Adds the OpenAPI schemas for RDF types."""
     if self.schema_objs is None:
       raise AssertionError("OpenAPI type schemas not initialized.")
+
+    for rdf_type_name in rdf_types_schemas:
+      old_description = rdf_types_schemas[rdf_type_name]['description']
+      new_prefix = f"RDF type is `{rdf_type_name}` and it represents"
+
+      if not old_description.startswith(new_prefix):
+        rdf_types_schemas[rdf_type_name]["description"] = (
+          f"{new_prefix} {old_description}"
+        )
 
     self.schema_objs.update(rdf_types_schemas)
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -137,49 +137,49 @@ rdf_types_schemas: Dict[str, Schema] = {
   "RDFDatetime": {
     "type": "string",
     "format": "uint64",
-    "description": "the number of microseconds since epoch to a timestamp.",
+    "description": "the number of microseconds since epoch to a timestamp",
   },
   "RDFDatetimeSeconds": {
     "type": "string",
     "format": "uint64",
-    "description": "the number of seconds since epoch to a timestamp.",
+    "description": "the number of seconds since epoch to a timestamp",
   },
   "Duration": {
     "type": "string",
     "format": "uint64",
-    "description": "the number of microseconds between two timestamps.",
+    "description": "the number of microseconds between two timestamps",
   },
   "DurationSeconds": {
     "type": "string",
     "format": "uint64",
-    "description": "the number of seconds between two timestamps.",
+    "description": "the number of seconds between two timestamps",
   },
   "RDFBytes": {
     "type": "string",
     "format": "byte",
-    "description": "a buffer of bytes.",
+    "description": "a buffer of bytes",
   },
   "HashDigest": {
     "type": "string",
     "format": "byte",
-    "description": "a binary hash digest with hex string representation.",
+    "description": "a binary hash digest with hex string representation",
   },
   "GlobExpression": {
     "type": "string",
-    "description": "a glob expression for a client path.",
+    "description": "a glob expression for a client path",
   },
   "ByteSize": {
     "type": "string",
     "format": "uint64",
-    "description": "a size for bytes allowing standard unit prefixes.",
+    "description": "a size for bytes allowing standard unit prefixes",
   },
   "RDFURN": {
     "type": "string",
-    "description": "an object to abstract URL manipulation.",
+    "description": "an object to abstract URL manipulation",
   },
   "SessionID": {
     "type": "string",
-    "description": "an rdfvalue object that represents a session_id.",
+    "description": "an rdfvalue object that represents a session_id",
   },
 }
 
@@ -252,15 +252,6 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     """Adds the OpenAPI schemas for RDF types."""
     if self.schema_objs is None:
       raise AssertionError("OpenAPI type schemas not initialized.")
-
-    for rdf_type_name in rdf_types_schemas:
-      old_description = rdf_types_schemas[rdf_type_name]['description']
-      new_prefix = f"RDF type is `{rdf_type_name}` and it represents"
-
-      if not old_description.startswith(new_prefix):
-        rdf_types_schemas[rdf_type_name]["description"] = (
-          f"{new_prefix} {old_description}"
-        )
 
     self.schema_objs.update(rdf_types_schemas)
 
@@ -549,6 +540,11 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
     if type_schema is not None:  # This happens with cyclic dependencies.
       type_description = type_schema.get("description")
       if type_description is not None:
+        if type_name in rdf_types_schemas:
+          type_description = (
+            f"RDF type is `{type_name}` and it represents {type_description}."
+          )
+
         if description:
           description += " "
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -39,6 +39,7 @@ DescribedSchema = Dict[str,
                        Union[str, List[SchemaReference], List[ArraySchema]]]
 Schema = Union[PrimitiveSchema, EnumSchema, MessageSchema, ArraySchema]
 PrimitiveDescription = Dict[str, Union[str, PrimitiveSchema]]
+RDFTypeDescription = Dict[str, Union[str, PrimitiveSchema]]
 TypeHinter = Union[Descriptor, FieldDescriptor, EnumDescriptor, Type, int, str]
 
 
@@ -132,15 +133,59 @@ primitive_types: Dict[Union[int, str], PrimitiveDescription] = {
   },
 }
 
-rdf_types: Dict[str, PrimitiveSchema] = {
-  "RDFDatetime": {"type": "string", "format": "date-time"},
-  "RDFDatetimeSeconds": {"type": "string", "format": "uint64"},
-  "Duration": {"type": "string", "format": "uint64"},
-  "DurationSeconds": {"type": "string", "format": "uint64"},
-  "RDFBytes": {"type": "string", "format": "byte"},
-  "HashDigest": {"type": "string", "format": "byte"},
-  "GlobExpression": {"type": "string", "format": "glob-expression"},
+rdf_types: Dict[str, RDFTypeDescription] = {
+  "RDFDatetime": {
+    "schema": {"type": "string", "format": "uint64"},
+    "description": "RDF type is `RDFDatetime` and it represents "
+                   "the number of microseconds since epoch to a timestamp.",
+  },
+  "RDFDatetimeSeconds": {
+    "schema": {"type": "string", "format": "uint64"},
+    "description": "RDF type is `RDFDatetimeSeconds` and it represents "
+                   "the number of seconds since epoch to a timestamp.",
+  },
+  "Duration": {
+    "schema": {"type": "string", "format": "uint64"},
+    "description": "RDF type is `Duration` and it represents "
+                   "the number of microseconds between two timestamps.",
+  },
+  "DurationSeconds": {
+    "schema": {"type": "string", "format": "uint64"},
+    "description": "RDF type is `DurationSeconds` and it represents "
+                   "the number of seconds between two timestamps.",
+  },
+  "RDFBytes": {
+    "schema": {"type": "string", "format": "byte"},
+    "description": "RDF type is `RDFBytes` and it represents "
+                   "a buffer of bytes.",
+  },
+  "HashDigest": {
+    "schema": {"type": "string", "format": "byte"},
+    "description": "RDF type is `HashDigest` and it represents "
+                   "a binary hash digest with hex string representation.",
+  },
+  "GlobExpression": {
+    "schema": {"type": "string"},
+    "description": "RDF type is `GlobExpression` and it represents "
+                   "a glob expression for a client path.",
+  },
+  "ByteSize": {
+    "schema": {"type": "string", "format": "uint64"},
+    "description": "RDF type is `ByteSize` and it represents "
+                   "a size for bytes allowing standard unit prefixes.",
+  },
+  "RDFURN": {
+    "schema": {"type": "string"},
+    "description": "RDF type is `RDFURN` and it represents "
+                   "an object to abstract URL manipulation.",
+  },
+  "SessionID": {
+    "schema": {"type": "string"},
+    "description": "RDF type is `SessionID` and it represents "
+                   "an rdfvalue object that represents a session_id.",
+  },
 }
+
 
 class ApiGetGrrVersionResult(rdf_structs.RDFProtoStruct):
   """An RDF wrapper for result of the API method for getting GRR version."""

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -544,7 +544,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       )
 
     # Add the description of the field's type which is stored with the type's
-    # schema. Examples of such descriptions are the ones of RDFTypes, the ones
+    # schema. Examples of such descriptions are the ones of RDF types, the ones
     # generated for `protobuf.map` types and for `protobuf.enum` types.
     type_schema = self.schema_objs.get(type_name)
     if type_schema is not None:  # This happens with cyclic dependencies.

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -132,6 +132,15 @@ primitive_types: Dict[Union[int, str], PrimitiveDescription] = {
   },
 }
 
+rdf_types: Dict[str, PrimitiveSchema] = {
+  "RDFDatetime": {"type": "string", "format": "date-time"},
+  "RDFDatetimeSeconds": {"type": "string", "format": "uint64"},
+  "Duration": {"type": "string", "format": "uint64"},
+  "DurationSeconds": {"type": "string", "format": "uint64"},
+  "RDFBytes": {"type": "string", "format": "byte"},
+  "HashDigest": {"type": "string", "format": "byte"},
+  "GlobExpression": {"type": "string", "format": "glob-expression"},
+}
 
 class ApiGetGrrVersionResult(rdf_structs.RDFProtoStruct):
   """An RDF wrapper for result of the API method for getting GRR version."""

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -553,7 +553,7 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
         if description:
           description += " "
 
-        description += type_description
+        description += cast(str, type_description)
 
     # The following `allOf` is required to display the description by
     # documentation generation tools because the OAS specifies that there

--- a/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
@@ -1498,8 +1498,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       {
         "type": "string",
         "format": "uint64",
-        "description": "RDF type is `RDFDatetime` and it represents "
-                       "the number of microseconds since epoch to a timestamp.",
+        "description": "the number of microseconds since epoch to a timestamp",
       },
       components_schemas["RDFDatetime"]
     )
@@ -1507,8 +1506,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       {
         "type": "string",
         "format": "uint64",
-        "description": "RDF type is `RDFDatetimeSeconds` and it represents "
-                       "the number of seconds since epoch to a timestamp.",
+        "description": "the number of seconds since epoch to a timestamp",
       },
       components_schemas["RDFDatetimeSeconds"]
     )
@@ -1516,8 +1514,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       {
         "type": "string",
         "format": "uint64",
-        "description": "RDF type is `Duration` and it represents "
-                       "the number of microseconds between two timestamps.",
+        "description": "the number of microseconds between two timestamps",
       },
       components_schemas["Duration"]
     )
@@ -1525,8 +1522,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       {
         "type": "string",
         "format": "uint64",
-        "description": "RDF type is `DurationSeconds` and it represents "
-                       "the number of seconds between two timestamps.",
+        "description": "the number of seconds between two timestamps",
       },
       components_schemas["DurationSeconds"]
     )
@@ -1534,8 +1530,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       {
         "type": "string",
         "format": "byte",
-        "description": "RDF type is `RDFBytes` and it represents "
-                       "a buffer of bytes.",
+        "description": "a buffer of bytes",
       },
       components_schemas["RDFBytes"]
     )
@@ -1543,16 +1538,14 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       {
         "type": "string",
         "format": "byte",
-        "description": "RDF type is `HashDigest` and it represents "
-                       "a binary hash digest with hex string representation.",
+        "description": "a binary hash digest with hex string representation",
       },
       components_schemas["HashDigest"]
     )
     self.assertEqual(
       {
         "type": "string",
-        "description": "RDF type is `GlobExpression` and it represents "
-                       "a glob expression for a client path.",
+        "description": "a glob expression for a client path",
       },
       components_schemas["GlobExpression"]
     )
@@ -1560,24 +1553,21 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       {
         "type": "string",
         "format": "uint64",
-        "description": "RDF type is `ByteSize` and it represents "
-                       "a size for bytes allowing standard unit prefixes.",
+        "description": "a size for bytes allowing standard unit prefixes",
       },
       components_schemas["ByteSize"]
     )
     self.assertEqual(
       {
         "type": "string",
-        "description": "RDF type is `RDFURN` and it represents "
-                       "an object to abstract URL manipulation.",
+        "description": "an object to abstract URL manipulation",
       },
       components_schemas["RDFURN"]
     )
     self.assertEqual(
       {
         "type": "string",
-        "description": "RDF type is `SessionID` and it represents "
-                       "an rdfvalue object that represents a session_id.",
+        "description": "an rdfvalue object that represents a session_id",
       },
       components_schemas["SessionID"]
     )

--- a/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
@@ -89,6 +89,7 @@ class MetadataSemTypeMessage(rdf_structs.RDFProtoStruct):
     rdfvalue.SessionID,
   ]
 
+
 class MetadataDummyApiCallRouter(api_call_router.ApiCallRouter):
   """Dummy `ApiCallRouter` implementation used for Metadata testing."""
 
@@ -1277,6 +1278,309 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
       )
 
     return None
+
+  def testRDFTypesAreCorrectlyDescribedAndUsedInOpenApiDescription(self):
+    # First, check that fields which have a `sem_type` protobuf field option are
+    # described using the `sem_type.type`'s schema.
+    expected_field_datetime = {
+      "description": "RDF type is `RDFDatetime` and it represents the number "
+                     "of microseconds since epoch to a timestamp.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/RDFDatetime",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_datetime,
+      self._GetParamSchema("/metadata_test/method10", "get", "field_datetime")
+    )
+    self.assertEqual(
+      expected_field_datetime,
+      self._GetParamSchema("/metadata_test/method10", "post", "field_datetime")
+    )
+
+    expected_field_datetimeseconds = {
+      "description": "RDF type is `RDFDatetimeSeconds` and it represents the "
+                     "number of seconds since epoch to a timestamp.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/RDFDatetimeSeconds",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_datetimeseconds,
+      self._GetParamSchema("/metadata_test/method10", "get",
+                           "field_datetimeseconds")
+    )
+    self.assertEqual(
+      expected_field_datetimeseconds,
+      self._GetParamSchema("/metadata_test/method10", "post",
+                           "field_datetimeseconds")
+    )
+
+    expected_field_duration = {
+      "description": "RDF type is `Duration` and it represents the number of "
+                     "microseconds between two timestamps.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/Duration",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_duration,
+      self._GetParamSchema("/metadata_test/method10", "get", "field_duration")
+    )
+    self.assertEqual(
+      expected_field_duration,
+      self._GetParamSchema("/metadata_test/method10", "post", "field_duration")
+    )
+
+    expected_field_durationseconds = {
+      "description": "RDF type is `DurationSeconds` and it represents the "
+                     "number of seconds between two timestamps.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/DurationSeconds",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_durationseconds,
+      self._GetParamSchema("/metadata_test/method10", "get",
+                           "field_durationseconds")
+    )
+    self.assertEqual(
+      expected_field_durationseconds,
+      self._GetParamSchema("/metadata_test/method10", "post",
+                           "field_durationseconds")
+    )
+
+    expected_field_rdfbytes = {
+      "description": "RDF type is `RDFBytes` and it represents a buffer of "
+                     "bytes.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/RDFBytes",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_rdfbytes,
+      self._GetParamSchema("/metadata_test/method10", "get", "field_rdfbytes")
+    )
+    self.assertEqual(
+      expected_field_rdfbytes,
+      self._GetParamSchema("/metadata_test/method10", "post", "field_rdfbytes")
+    )
+
+    expected_field_hashdigest = {
+      "description": "RDF type is `HashDigest` and it represents a binary hash "
+                     "digest with hex string representation.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/HashDigest",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_hashdigest,
+      self._GetParamSchema("/metadata_test/method10", "get", "field_hashdigest")
+    )
+    self.assertEqual(
+      expected_field_hashdigest,
+      self._GetParamSchema("/metadata_test/method10", "post",
+                           "field_hashdigest")
+    )
+
+    expected_field_globexpression = {
+      "description": "RDF type is `GlobExpression` and it represents a glob "
+                     "expression for a client path.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/GlobExpression",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_globexpression,
+      self._GetParamSchema("/metadata_test/method10", "get",
+                           "field_globexpression")
+    )
+    self.assertEqual(
+      expected_field_globexpression,
+      self._GetParamSchema("/metadata_test/method10", "post",
+                           "field_globexpression")
+    )
+
+    expected_field_bytesize = {
+      "description": "RDF type is `ByteSize` and it represents a size for "
+                     "bytes allowing standard unit prefixes.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/ByteSize",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_bytesize,
+      self._GetParamSchema("/metadata_test/method10", "get", "field_bytesize")
+    )
+    self.assertEqual(
+      expected_field_bytesize,
+      self._GetParamSchema("/metadata_test/method10", "post", "field_bytesize")
+    )
+
+    expected_field_rdfurn = {
+      "description": "RDF type is `RDFURN` and it represents an object to "
+                     "abstract URL manipulation.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/RDFURN",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_rdfurn,
+      self._GetParamSchema("/metadata_test/method10", "get", "field_rdfurn")
+    )
+    self.assertEqual(
+      expected_field_rdfurn,
+      self._GetParamSchema("/metadata_test/method10", "post", "field_rdfurn")
+    )
+
+    expected_field_sessionid = {
+      "description": "RDF type is `SessionID` and it represents an rdfvalue "
+                     "object that represents a session_id.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/SessionID",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_field_sessionid,
+      self._GetParamSchema("/metadata_test/method10", "get", "field_sessionid")
+    )
+    self.assertEqual(
+      expected_field_sessionid,
+      self._GetParamSchema("/metadata_test/method10", "post", "field_sessionid")
+    )
+
+    # Check that descriptions get concatenated in the case we have a
+    # `protobuf.oneof` field that has an RDF type `sem_type.type`.
+    expected_oneof_datetime = {
+      "description": "This field is part of the \"semtype_oneof\" oneof. Only "
+                     "one field per oneof should be present. RDF type is "
+                     "`RDFDatetime` and it represents the number of "
+                     "microseconds since epoch to a timestamp.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/RDFDatetime",
+        },
+      ],
+    }
+    self.assertEqual(
+      expected_oneof_datetime,
+      self._GetParamSchema("/metadata_test/method10", "get", "oneof_datetime")
+    )
+    self.assertEqual(
+      expected_oneof_datetime,
+      self._GetParamSchema("/metadata_test/method10", "post", "oneof_datetime")
+    )
+
+    # Now check that the RDF types have their schemas correctly described.
+    components_schemas = self.openapi_desc_dict["components"]["schemas"]
+
+    self.assertEqual(
+      {
+        "type": "string",
+        "format": "uint64",
+        "description": "RDF type is `RDFDatetime` and it represents "
+                       "the number of microseconds since epoch to a timestamp.",
+      },
+      components_schemas["RDFDatetime"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "format": "uint64",
+        "description": "RDF type is `RDFDatetimeSeconds` and it represents "
+                       "the number of seconds since epoch to a timestamp.",
+      },
+      components_schemas["RDFDatetimeSeconds"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "format": "uint64",
+        "description": "RDF type is `Duration` and it represents "
+                       "the number of microseconds between two timestamps.",
+      },
+      components_schemas["Duration"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "format": "uint64",
+        "description": "RDF type is `DurationSeconds` and it represents "
+                       "the number of seconds between two timestamps.",
+      },
+      components_schemas["DurationSeconds"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "format": "byte",
+        "description": "RDF type is `RDFBytes` and it represents "
+                       "a buffer of bytes.",
+      },
+      components_schemas["RDFBytes"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "format": "byte",
+        "description": "RDF type is `HashDigest` and it represents "
+                       "a binary hash digest with hex string representation.",
+      },
+      components_schemas["HashDigest"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "description": "RDF type is `GlobExpression` and it represents "
+                       "a glob expression for a client path.",
+      },
+      components_schemas["GlobExpression"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "format": "uint64",
+        "description": "RDF type is `ByteSize` and it represents "
+                       "a size for bytes allowing standard unit prefixes.",
+      },
+      components_schemas["ByteSize"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "description": "RDF type is `RDFURN` and it represents "
+                       "an object to abstract URL manipulation.",
+      },
+      components_schemas["RDFURN"]
+    )
+    self.assertEqual(
+      {
+        "type": "string",
+        "description": "RDF type is `SessionID` and it represents "
+                       "an rdfvalue object that represents a session_id.",
+      },
+      components_schemas["SessionID"]
+    )
 
 
 def main(argv):


### PR DESCRIPTION
In this PR I extract the [`SemanticDescriptor` `sem_type`](https://github.com/google/grr/blob/b472626b6ff4d05b24269a7ce52419d00a847607/grr/proto/grr_response_proto/semantic.proto#L8) protobuf field option and use its `type` field to describe message fields and parameters in the generated OpenAPI description of the GRR API.

I use a dictionary of supported RDF types for which we have an OpenAPI schema including a description which specifies what that type actually represents. The RDF types included are all the ones defined in [`grr_response_core/lib/rdfvalue.py`](https://github.com/google/grr/blob/master/grr/core/grr_response_core/lib/rdfvalue.py) and [`grr_response_core/lib/rdfvalues/paths.py`](https://github.com/google/grr/blob/master/grr/core/grr_response_core/lib/rdfvalues/paths.py) which are used at least once as the `type` in a `sem_type` protobuf field option. Please let me know if any types should be added or removed.

_Please note that I use the ":thumbsup:" emoji to mark comments that I've addressed in a yet to be created / pushed commit._