### PR TITLE
On query support for time range

### DIFF
--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -148,8 +148,8 @@ def _FetchDatapointsForTargets(
     targets: Iterable[str]) -> List[_TargetWithDatapoints]:
   """Fetches a list of <datapoint, timestamp> tuples for each target 
   metric from Fleetspeak database."""
-  start_range_timestamp = GrafanaTimestampToTimestampObj(start_range)
-  end_range_timestamp = GrafanaTimestampToTimestampObj(end_range)
+  start_range_timestamp = timeToProtoTimestamp(start_range)
+  end_range_timestamp = timeToProtoTimestamp(end_range)
   records_list = fleetspeak_utils.FetchClientResourceUsageRecords(
       client_id, start_range_timestamp, end_range_timestamp)
   response = []
@@ -162,7 +162,7 @@ def _FetchDatapointsForTargets(
   return response
 
 
-def GrafanaTimestampToTimestampObj(
+def timeToProtoTimestamp(
     grafana_time: str) -> timestamp_pb2.Timestamp:
   date = dateutil.parser.parse(grafana_time)
   return timestamp_pb2.Timestamp(seconds=int(date.timestamp()),

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -5,7 +5,7 @@ import collections
 import dateutil
 import json
 import os
-from typing import Any, cast, Dict, List, Text, Tuple, Iterable
+from typing import Any, cast, Dict, List, Tuple, Iterable
 
 from fleetspeak.src.server.proto.fleetspeak_server import resource_pb2
 from google.protobuf import timestamp_pb2
@@ -143,13 +143,13 @@ _TargetWithDatapoints = collections.namedtuple("TargetWithDatapoints",
 
 
 def _FetchDatapointsForTargets(
-    client_id: Text, start_range: Text,
-    end_range: Text,
-    targets: Iterable[Text]) -> List[_TargetWithDatapoints]:
+    client_id: str, start_range: str,
+    end_range: str,
+    targets: Iterable[str]) -> List[_TargetWithDatapoints]:
   """Fetches a list of <datapoint, timestamp> tuples for each target 
   metric from Fleetspeak database."""
-  start_range_timestamp = _GrafanaTimestampToTimestampObj(start_range)
-  end_range_timestamp = _GrafanaTimestampToTimestampObj(end_range)
+  start_range_timestamp = GrafanaTimestampToTimestampObj(start_range)
+  end_range_timestamp = GrafanaTimestampToTimestampObj(end_range)
   records_list = fleetspeak_utils.FetchClientResourceUsageRecords(
       client_id, start_range_timestamp, end_range_timestamp)
   response = []
@@ -162,15 +162,15 @@ def _FetchDatapointsForTargets(
   return response
 
 
-def _GrafanaTimestampToTimestampObj(
-    grafana_time: Text) -> timestamp_pb2.Timestamp:
+def GrafanaTimestampToTimestampObj(
+    grafana_time: str) -> timestamp_pb2.Timestamp:
   date = dateutil.parser.parse(grafana_time)
   return timestamp_pb2.Timestamp(seconds=int(date.timestamp()),
                                  nanos=date.microsecond * 1000)
 
 
 def _CreateDatapointsForTarget(
-    target: Text,
+    target: str,
     records_list: Iterable[resource_pb2.ClientResourceUsageRecord]
 ) -> _Datapoints:
   if target == "mean_user_cpu_rate":
@@ -197,7 +197,7 @@ def _CreateDatapointsForTarget(
   ]
 
 
-def _ExtractClientIdFromVariable(req: JSONRequest) -> Text:
+def _ExtractClientIdFromVariable(req: JSONRequest) -> str:
   """Extracts the client ID from a Grafana JSON request."""
   return req["scopedVars"]["ClientID"]["value"]
 

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -215,16 +215,16 @@ class GrrafanaTest(absltest.TestCase):
                         json=_TEST_INVALID_TARGET_QUERY)
 
 
-class GrafanaTimestampToTimestampObjTest(absltest.TestCase):
+class timeToProtoTimestampTest(absltest.TestCase):
   """Test the conversion between a timestamp issued by Grafana
   (ISO 8601) to a Timestamp object transferable to Fleetspeak by gRPC."""
 
-  def testGrafanaTimestampToTimestampObj(self):
+  def testtimeToProtoTimestamp(self):
     self.assertEqual(
-        grrafana.GrafanaTimestampToTimestampObj(_START_RANGE_TIMESTAMP),
+        grrafana.timeToProtoTimestamp(_START_RANGE_TIMESTAMP),
         timestamp_pb2.Timestamp(seconds=1597328417, nanos=(158 * 1000000)))
     self.assertEqual(
-        grrafana.GrafanaTimestampToTimestampObj(_END_RANGE_TIMESTAMP),
+        grrafana.timeToProtoTimestamp(_END_RANGE_TIMESTAMP),
         timestamp_pb2.Timestamp(seconds=1597770958, nanos=(761 * 1000000)))
 
 

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -214,12 +214,17 @@ class GrrafanaTest(absltest.TestCase):
                         "/query",
                         json=_TEST_INVALID_TARGET_QUERY)
 
+
+class GrafanaTimestampToTimestampObjTest(absltest.TestCase):
+  """Test the conversion between a timestamp issued by Grafana
+  (ISO 8601) to a Timestamp object transferable to Fleetspeak by gRPC."""
+
   def testGrafanaTimestampToTimestampObj(self):
     self.assertEqual(
-        grrafana._GrafanaTimestampToTimestampObj(_START_RANGE_TIMESTAMP),
+        grrafana.GrafanaTimestampToTimestampObj(_START_RANGE_TIMESTAMP),
         timestamp_pb2.Timestamp(seconds=1597328417, nanos=(158 * 1000000)))
     self.assertEqual(
-        grrafana._GrafanaTimestampToTimestampObj(_END_RANGE_TIMESTAMP),
+        grrafana.GrafanaTimestampToTimestampObj(_END_RANGE_TIMESTAMP),
         timestamp_pb2.Timestamp(seconds=1597770958, nanos=(761 * 1000000)))
 
 

--- a/grr/server/grr_response_server/fleetspeak_utils.py
+++ b/grr/server/grr_response_server/fleetspeak_utils.py
@@ -8,6 +8,8 @@ from __future__ import unicode_literals
 import binascii
 from typing import Text, List
 
+from google.protobuf import timestamp_pb2
+
 from grr_response_core import config
 from grr_response_core.lib import rdfvalue
 from grr_response_core.lib.util import text
@@ -116,20 +118,25 @@ def GetLabelsFromFleetspeak(client_id):
 
 
 def FetchClientResourceUsageRecords(
-    client_id: Text, limit: int) -> List[resource_pb2.ClientResourceUsageRecord]:
+    client_id: Text, start_range: timestamp_pb2.Timestamp,
+    end_range: timestamp_pb2.Timestamp
+) -> List[resource_pb2.ClientResourceUsageRecord]:
   """Returns aggregated resource usage metrics of a client
-  in Fleetspeak-enabled database.
+  in Fleetspeak-enabled database within a specified time range.
 
   Args:
     client_id: Id of the client to fetch Fleetspeak resource usage records for.
-    limit: Max number of resource usage records to retrieve.
+    start_range: Start timestamp of range.
+    end_range: end timestamp of range.
 
   Returns:
     A list of client resource usage records retrieved from Fleetspeak.
   """
   res = fleetspeak_connector.CONN.outgoing.FetchClientResourceUsageRecords(
       admin_pb2.FetchClientResourceUsageRecordsRequest(
-          client_id=GRRIDToFleetspeakID(client_id), limit=limit))
+          client_id=GRRIDToFleetspeakID(client_id),
+          start_timestamp=start_range,
+          end_timestamp = end_range))
   if not res.records:
     return []
   return list(res.records)

--- a/grr/server/grr_response_server/fleetspeak_utils.py
+++ b/grr/server/grr_response_server/fleetspeak_utils.py
@@ -118,7 +118,7 @@ def GetLabelsFromFleetspeak(client_id):
 
 
 def FetchClientResourceUsageRecords(
-    client_id: Text, start_range: timestamp_pb2.Timestamp,
+    client_id: str, start_range: timestamp_pb2.Timestamp,
     end_range: timestamp_pb2.Timestamp
 ) -> List[resource_pb2.ClientResourceUsageRecord]:
   """Returns aggregated resource usage metrics of a client

--- a/grr/server/grr_response_server/fleetspeak_utils.py
+++ b/grr/server/grr_response_server/fleetspeak_utils.py
@@ -136,7 +136,7 @@ def FetchClientResourceUsageRecords(
       admin_pb2.FetchClientResourceUsageRecordsRequest(
           client_id=GRRIDToFleetspeakID(client_id),
           start_timestamp=start_range,
-          end_timestamp = end_range))
+          end_timestamp=end_range))
   if not res.records:
     return []
   return list(res.records)

--- a/grr/server/grr_response_server/fleetspeak_utils_test.py
+++ b/grr/server/grr_response_server/fleetspeak_utils_test.py
@@ -8,6 +8,8 @@ from __future__ import unicode_literals
 from absl import app
 import mock
 
+from google.protobuf import timestamp_pb2
+
 from grr_response_core.lib.rdfvalues import flows as rdf_flows
 from grr_response_server import fleetspeak_connector
 from grr_response_server import fleetspeak_utils
@@ -150,14 +152,18 @@ class FleetspeakUtilsTest(test_lib.GRRBaseTest):
           resource_pb2.ClientResourceUsageRecord(mean_user_cpu_rate=4,
                                                  max_system_cpu_rate=8)
       ]
+      arbitrary_date = timestamp_pb2.Timestamp(seconds=1, nanos=1)
       self.assertListEqual(
           fleetspeak_utils.FetchClientResourceUsageRecords(
-              _TEST_CLIENT_ID, 10), expected_records_list)
+              client_id=_TEST_CLIENT_ID,
+              start_range=arbitrary_date,
+              end_range=arbitrary_date), expected_records_list)
       conn.outgoing.FetchClientResourceUsageRecords.assert_called_once()
       conn.outgoing.FetchClientResourceUsageRecords.assert_called_with(
           admin_pb2.FetchClientResourceUsageRecordsRequest(
               client_id=fleetspeak_utils.GRRIDToFleetspeakID(_TEST_CLIENT_ID),
-              limit=10))
+              start_timestamp=arbitrary_date,
+              end_timestamp=arbitrary_date))
 
 
 def main(argv):


### PR DESCRIPTION
Following a discussion on google/fleetspeak#281, we would like to pass a time range to the `/query` API endpoint rather than a specified `limit`. This way, we can retrieve much more meaningful and more accurate datapoints from Fleetspeak's database.

Note that this PR depends on google/fleetspeak#294, and will work only once google/fleetspeak#294 is merged.