### PR TITLE
Use `/api/v2/...` when describing route paths in OpenAPI description

### DIFF
--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -908,6 +908,9 @@ def _NormalizePath(path: str) -> str:
   normalized_components = [
     _NormalizePathComponent(component) for component in components
   ]
+  if normalized_components[1] == "api":
+    # We describe the v2 API in the OpenAPI description.
+    normalized_components.insert(2, "v2")
 
   normalized_path = "/".join(normalized_components)
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -908,7 +908,10 @@ def _NormalizePath(path: str) -> str:
   normalized_components = [
     _NormalizePathComponent(component) for component in components
   ]
-  if normalized_components[1] == "api":
+  if (
+      normalized_components[1] == "api"
+      and (len(normalized_components) == 2 or normalized_components[2] != "v2")
+  ):
     # We describe the v2 API in the OpenAPI description.
     normalized_components.insert(2, "v2")
 


### PR DESCRIPTION
In this PR I replace the `/api/...` path component from the paths annotated to router methods with `/api/v2/...` in the generated OpenAPI description in order to point users to routes of the API that return the described fields with the described level of nesting.