### PR TITLE
Fix bug in OpenAPI description generation related to trailing slashes in routes

### DIFF
--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -804,6 +804,10 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       ungrouped_routes = []
       for http_method, path, strip_root_types in router_method.http_methods:
         path_components = path.split("/")
+        # Remove trailing empty strings from the list of path components.
+        while path_components and len(path_components[-1]) == 0:
+          path_components.pop()
+
         ungrouped_routes.append([http_method] + path_components)
 
       grouped_routes = _GetGroupedRoutes(ungrouped_routes)

--- a/grr/server/grr_response_server/gui/api_plugins/metadata.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata.py
@@ -804,9 +804,10 @@ class ApiGetOpenApiDescriptionHandler(api_call_handler_base.ApiCallHandler):
       ungrouped_routes = []
       for http_method, path, strip_root_types in router_method.http_methods:
         path_components = path.split("/")
-        # Remove trailing empty strings from the list of path components.
-        while path_components and len(path_components[-1]) == 0:
-          path_components.pop()
+        # Remove any empty strings from the list of path components.
+        path_components = list(
+          filter(lambda comp: len(comp) > 0, path_components)
+        )
 
         ungrouped_routes.append([http_method] + path_components)
 
@@ -920,6 +921,8 @@ def _NormalizePath(path: str) -> str:
     normalized_components.insert(2, "v2")
 
   normalized_path = "/".join(normalized_components)
+  if not normalized_path.startswith("/"):
+    normalized_path = "/" + normalized_path
 
   return normalized_path
 

--- a/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/metadata_test.py
@@ -160,6 +160,11 @@ class MetadataDummyApiCallRouter(api_call_router.ApiCallRouter):
   @api_call_router.Http(
     "GET", "/metadata_test/method9/<metadata_id>/fixed1/<metadata_arg1>"
   )
+  @api_call_router.Http("GET", "/metadata_test/method9/fixed2/")  # Trailing /.
+  @api_call_router.Http("GET", "/metadata_test/method9/fixed2/<metadata_arg1>/")
+  @api_call_router.Http(
+    "GET", "/metadata_test/method9/fixed2/<metadata_arg1>/<metadata_arg2>/"
+  )
   def Method9OptionalPathArgs(self, args, token=None):
     """Method 9 description"""
 
@@ -232,6 +237,7 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
         "/metadata_test/method9/{metadataId}/{metadataArg1}",
         "/metadata_test/method9/{metadataId}/{metadataArg1}/{metadataArg2}",
         "/metadata_test/method9/{metadataId}/fixed1/{metadataArg1}",
+        "/metadata_test/method9/fixed2/{metadataArg1}/{metadataArg2}",
         "/metadata_test/method10",
       },
       openapi_paths_dict.keys()
@@ -1238,6 +1244,52 @@ class ApiGetOpenApiDescriptionHandlerTest(api_test_lib.ApiCallHandlerTest):
         ),
       ]
     )
+
+    # Test `GET /metadata_test/method9/fixed2/{metadataArg1}/{metadataArg2}`
+    # parameters.
+    self.assertCountEqual(
+      [
+        {
+          "name": "metadataId",
+          "in": "query",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_STRING",
+          },
+        },
+        {
+          "name": "metadataArg1",
+          "in": "path",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_INT64",
+          },
+        },
+        {
+          "name": "metadataArg2",
+          "in": "path",
+          "schema": {
+            "$ref": "#/components/schemas/protobuf2.TYPE_BOOL",
+          },
+        },
+      ],
+      [
+        self._GetParamDescription(
+          "/metadata_test/method9/fixed2/{metadataArg1}/{metadataArg2}",
+          "get",
+          "metadataId"
+        ),
+        self._GetParamDescription(
+          "/metadata_test/method9/fixed2/{metadataArg1}/{metadataArg2}",
+          "get",
+          "metadataArg1"
+        ),
+        self._GetParamDescription(
+          "/metadata_test/method9/fixed2/{metadataArg1}/{metadataArg2}",
+          "get",
+          "metadataArg2"
+        ),
+      ]
+    )
+
 
   def _GetParamDescription(self, method_path, http_method, param_name):
     params = (


### PR DESCRIPTION
A [couple of routes](https://github.com/google/grr/blob/77c87c29b4f5c76cbe26ed7a48a37a32a2c12c24/grr/server/grr_response_server/gui/api_call_router.py#L350-L363) have a trailing "/" in their path. This caused an extra empty string to be added to the list of path components when using `path.split("/")` and in turn, this caused the optional path parameter extraction algorithm to fail because the route adding a new path parameter would actually add 2 new path components, instead of one (the actual path parameter).

This PR solves this bug and adds to an existing test in order to verify this case too,