### PR TITLE
Grafana Dashboard for Client Load Stats

### DIFF
--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -25,12 +25,12 @@ from werkzeug import wsgi as werkzeug_wsgi
 from werkzeug.wrappers import json as werkzeug_wrappers_json
 
 AVAILABLE_METRICS = [
-    "mean_user_cpu_rate",
-    "max_user_cpu_rate",
-    "mean_system_cpu_rate",
-    "max_system_cpu_rate",
-    "mean_resident_memory_mib",
-    "max_resident_memory_mib",
+    "Mean User CPU Rate",
+    "Max User CPU Rate",
+    "Mean System CPU Rate",
+    "Max System CPU Rate",
+    "Mean Resident Memory MB",
+    "Max Resident Memory MB",
 ]
 
 JSON_MIME_TYPE = "application/json"
@@ -173,18 +173,23 @@ def _CreateDatapointsForTarget(
     target: str,
     records_list: Iterable[resource_pb2.ClientResourceUsageRecord]
 ) -> _Datapoints:
-  if target == "mean_user_cpu_rate":
+  if target == "Mean User CPU Rate":
     record_values = [record.mean_user_cpu_rate for record in records_list]
-  elif target == "max_user_cpu_rate":
+  elif target == "Max User CPU Rate":
     record_values = [record.max_user_cpu_rate for record in records_list]
-  elif target == "mean_system_cpu_rate":
+  elif target == "Mean System CPU Rate":
     record_values = [record.mean_system_cpu_rate for record in records_list]
-  elif target == "max_system_cpu_rate":
+  elif target == "Max System CPU Rate":
     record_values = [record.max_system_cpu_rate for record in records_list]
-  elif target == "mean_resident_memory_mib":
-    record_values = [record.mean_resident_memory_mib for record in records_list]
-  elif target == "max_resident_memory_mib":
-    record_values = [record.max_resident_memory_mib for record in records_list]
+  elif target == "Mean Resident Memory MB":
+    record_values = [
+        # conversion from MiB to MB.
+        record.mean_resident_memory_mib * 1.049 for record in records_list
+    ]
+  elif target == "Max Resident Memory MB":
+    record_values = [
+        record.max_resident_memory_mib * 1.049 for record in records_list
+    ]
   else:
     raise NameError(
         f"Target {target} is not a resource usage metric that can be " \

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -84,13 +84,13 @@ _TEST_VALID_QUERY = {
     'intervalMs': 600000,
     'targets': [{
         'data': None,
-        'target': 'max_user_cpu_rate',
+        'target': 'Max User CPU Rate',
         'refId': 'A',
         'hide': False,
         'type': 'timeseries'
     }, {
         'data': None,
-        'target': 'mean_system_cpu_rate',
+        'target': 'Mean System CPU Rate',
         'refId': 'A',
         'hide': False,
         'type': 'timeseries'
@@ -175,12 +175,12 @@ class GrrafanaTest(absltest.TestCase):
                                 })
     self.assertEqual(200, response.status_code)
     self.assertListEqual(response.json, [
-        "mean_user_cpu_rate",
-        "max_user_cpu_rate",
-        "mean_system_cpu_rate",
-        "max_system_cpu_rate",
-        "mean_resident_memory_mib",
-        "max_resident_memory_mib",
+        "Mean User CPU Rate",
+        "Max User CPU Rate",
+        "Mean System CPU Rate",
+        "Max System CPU Rate",
+        "Mean Resident Memory MB",
+        "Max Resident Memory MB",
     ])
 
   def testQuery(self):
@@ -193,12 +193,12 @@ class GrrafanaTest(absltest.TestCase):
       self.assertEqual(200, valid_response.status_code)
       self.assertEqual(valid_response.json, [{
           "target":
-              "max_user_cpu_rate",
+              "Max User CPU Rate",
           "datapoints": [[4.999776840209961, 1597328417823],
                          [4.999615669250488, 1597328419403]]
       }, {
           "target":
-              "mean_system_cpu_rate",
+              "Mean System CPU Rate",
           "datapoints": [[0.31883034110069275, 1597328417823],
                          [0.07246342301368713, 1597328419403]]
       }])

--- a/monitoring/grafana/grr_grafanalib_dashboards/config.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/config.py
@@ -1,12 +1,13 @@
 from grr_grafanalib_dashboards import reusable_panels
 
-# The data source name is specified after Grafana is set up
+# The data source names are specified after Grafana is set up
 # and it can be visited at localhost:3000.
-# In GRR Monitoring docs, we suggest naming it "grr-server", but if it's
-# not the case, change it here.
+# In GRR Monitoring docs, we suggest naming the data sources "grr-server"
+# and "grrafana" respectively, but if it's not the case, change it here.
 # For reference, take a look at the docs here:
 # https://grr-doc.readthedocs.io/en/latest/maintaining-and-tuning/monitoring.html#example-visualization-and-alerting-setup
 GRAFANA_DATA_SOURCE = "grr-server"
+CLIENT_LOAD_STATS_DATA_SOURCE = "grrafana"
 
 # An alert will be fired if the number of active processes (of any
 # GRR server component) is below this number.

--- a/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_for_use/client_load_stats.json
+++ b/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_for_use/client_load_stats.json
@@ -1,0 +1,426 @@
+{
+  "__inputs": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "grrafana",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": null,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "",
+              "expr": "",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": "Mean User CPU Rate"
+            },
+            {
+              "datasource": "",
+              "expr": "",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": "Max User CPU Rate"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "User CPU Usage",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": 105,
+              "min": 0,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "grrafana",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": null,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "",
+              "expr": "",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": "Mean System CPU Rate"
+            },
+            {
+              "datasource": "",
+              "expr": "",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": "Max System CPU Rate"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "System CPU Usage",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": 105,
+              "min": 0,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "showTitle": false,
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "grrafana",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "minSpan": null,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": null,
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": "",
+              "expr": "",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": "Mean Resident Memory MB"
+            },
+            {
+              "datasource": "",
+              "expr": "",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "target": "Max Resident Memory MB"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Resident Memory",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": false,
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "decmbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "showTitle": false,
+      "title": "New row"
+    }
+  ],
+  "schemaVersion": 12,
+  "sharedCrosshair": false,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": null,
+          "value": null
+        },
+        "datasource": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "ClientID",
+        "options": [],
+        "query": "",
+        "refresh": 1,
+        "regex": null,
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tagsQuery": null,
+        "type": "textbox",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Client Load Stats Dashboard",
+  "uid": null,
+  "version": 0
+}

--- a/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_to_generate/client_load_stats.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_to_generate/client_load_stats.dashboard.py
@@ -1,0 +1,54 @@
+from grafanalib.core import Dashboard, Graph, Row, Target, Template, Templating, YAxes, YAxis
+from grr_grafanalib_dashboards.util import add_data_source
+from grr_grafanalib_dashboards.config import CLIENT_LOAD_STATS_DATA_SOURCE
+
+client_id_variable = Template(name="ClientID", query="", type="textbox")
+
+dashboard = Dashboard(
+    title="Client Load Stats Dashboard",
+    templating=Templating([client_id_variable]),
+    rows=[
+        Row(panels=[
+            Graph(
+                title="User CPU Usage",
+                targets=[
+                    Target(
+                        target='Mean User CPU Rate',
+                    ),
+                    Target(
+                        target='Max User CPU Rate',
+                    ),
+                ],
+                yAxes=YAxes(left=YAxis(max=105, format="percent")),
+            ),
+            Graph(
+                title="System CPU Usage",
+                targets=[
+                    Target(
+                        target='Mean System CPU Rate',
+                    ),
+                    Target(
+                        target='Max System CPU Rate',
+                    ),
+                ],
+                yAxes=YAxes(left=YAxis(max=105, format="percent")),
+            ),
+        ]),
+        Row(panels=[
+            Graph(
+                title="Resident Memory",
+                targets=[
+                    Target(
+                        target='Mean Resident Memory MB',
+                    ),
+                    Target(
+                        target='Max Resident Memory MB',
+                    ),
+                ],
+                yAxes=YAxes(left=YAxis(format="decmbytes")),
+            ),
+        ]),
+    ],
+).auto_panel_ids()
+
+dashboard = add_data_source(dashboard, CLIENT_LOAD_STATS_DATA_SOURCE)


### PR DESCRIPTION
This PR introduces a new [Grafana Dashboard](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/#dashboard-overview) to GRR for the **Client Load Stats** page. The statistics in the dashboard are gathered from the Fleetspeak client (rather than the current page that gathers its information from the GRR client). The statistics are queried from Grafana using [JSON Datasource plugin](https://github.com/simPod/grafana-json-datasource), and are processed in GRRafana HTTP server (the full details of GRRafana HTTP server and the interaction are described in #832).
The changes directly related to the dashboard are in the Python package `grr_grafanalib_dashboards`, as presented in #783.

Here's a snapshot of the new dashboard:
![canvas](https://user-images.githubusercontent.com/10086302/93977847-cb34ce00-fd83-11ea-8dcd-4e1fd35e5a8a.png)
You may notice that this dashboard contains a Grafana [textbox variable](https://grafana.com/docs/grafana/latest/variables/variable-types/add-text-box-variable/#add-a-text-box-variable), where the user may insert a GRR client ID. As discussed in previous PRs, this variable does not support auto-completion since the number of client IDs may be too large and jam the Grafana server instance.

The other changes are within the GRRafana HTTP server. I've made two main changes that concern the new dashboard, as follows:
- Changed the names of the available metrics to fetch to a more "displayable" format (e.g., `max_user_cpu_rate` to `Max User CPU Rate`). The reason is that JSON Datasource plugin lacks a customizeable legend format field, like the built in [Prometheus datasource plugin](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/#prometheus-data-source). For further information, you can visit the [relevant issue](https://github.com/simPod/grafana-json-datasource/issues/14).
- Converted the two metrics that use MiB as units to MB. This is since Grafana itself does not have MiB as an option for [Y-axis labels](https://grafana.com/docs/grafana/latest/panels/visualizations/graph-panel/#left-yright-y). Therefore, while we collect the metrics, we make the appropriate conversion.