### PR TITLE
GRRafana: Add support to query Client Breakdown Statistics

### DIFF
--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -129,7 +129,7 @@ AVAILABLE_METRICS_LIST = [
     ClientResourceUsageMetric(
         "Max System CPU Rate", lambda records_list:
         [record.max_system_cpu_rate for record in records_list]),
-    # We multiply to convert from MiB to MB
+    # Converting MiB to MB
     ClientResourceUsageMetric(
         "Mean Resident Memory MB", lambda records_list:
         [record.mean_resident_memory_mib * 1.049 for record in records_list]),

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -199,17 +199,7 @@ class Grrafana(object):
     Depending on the type of request Grafana is issuing, this method returns
     either available client resource usage metrics from the constant
     AVAILABLE_METRICS, or possible values for a defined Grafana variable."""
-    if "type" in request.json:
-      # Grafana request issued on Panel > Queries page. Grafana expects the
-      # list of metrics that can be listed on the dropdown-menu
-      # called "Metric".
-      response = list(AVAILABLE_METRICS_DICT.keys())
-    else:
-      # Grafana request issued on Variables > New/Edit page for variables of
-      # type query. Grafana expectes the list of possible values of
-      # the variable. At the moment, GRRafana doesn't support such variables,
-      # so it returns no possible values.
-      response = []
+    response = list(AVAILABLE_METRICS_DICT.keys())
     return JSONResponse(response=response)
 
   def _OnQuery(self, request: JSONRequest) -> JSONResponse:

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -3,7 +3,7 @@
 import abc
 from absl import app, flags
 import collections
-import dateutil
+from dateutil import parser
 import json
 import os
 from typing import Any, Callable, Dict, List, NamedTuple, Tuple
@@ -256,7 +256,7 @@ class Grrafana(object):
 
 def timeToProtoTimestamp(
     grafana_time: str) -> timestamp_pb2.Timestamp:
-  date = dateutil.parser.parse(grafana_time)  # type: ignore
+  date = parser.parse(grafana_time)
   return timestamp_pb2.Timestamp(seconds=int(date.timestamp()),
                                  nanos=date.microsecond * 1000)
 

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -103,31 +103,15 @@ class ClientsStatisticsMetric(Metric):
 
   def ProcessQuery(self, req: JSONRequest):
     fleet_stats = self.statistics_extract_fn(frozenset([self.days_active]))
-    # for day_bucket in fleet_stats.GetDayBuckets():
-    # graph = rdf_stats.Graph(title="%d day actives for %s label" %
-    #                         (day_bucket, _ALL_CLIENT_FLEET_STATS_LABEL))
     totals = fleet_stats.GetTotalsForDay(self.days_active)
-    print(totals)
     return _TableQueryResult(columns=[{
-        "text": "Country",
-        "type": "string"
-    }, {
-        "text": "Number",
-        "type": "number"
-    }],
-                             rows=[["SE", 123], ["DE", 231], ["US", 321]],
-                             type="table")
-    # print(type(totals))
-    # datapoints = [
-    #     _TargetWithDatapoints(target=category_value, datapoints=num_actives)
-    #     for category_value, num_actives in sorted(totals.items())
-    # ]
-    # print(datapoints)
-    # for category_value, num_actives in sorted(totals.items()):
-    # graph.Append(label=category_value, y_value=num_actives)
-    # _TargetWithDatapoints(target=self.name, datapoints=datapoints)
-    # graph_series_by_label[_ALL_CLIENT_FLEET_STATS_LABEL].graphs.Append(graph)
-    # return _TargetWithDatapoints(target=self.name, datapoints=list(totals.items()))
+        "text": "Label", "type":"string"
+      }, {
+        "text": "Value", "type": "number"
+      }],
+                            rows=[[label, value] for label, value
+                                  in totals.items()],
+                            type="table")
 
 
 AVAILABLE_METRICS_LIST = [

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -101,19 +101,21 @@ class ClientsStatisticsMetric(Metric):
     self.statistics_extract_fn = statistics_extract_fn
     self.days_active = days_active
 
-  def ProcessQuery(self, req: JSONRequest):
+  def ProcessQuery(self, req: JSONRequest) -> _TableQueryResult:
     fleet_stats = self.statistics_extract_fn(frozenset([self.days_active]))
     totals = fleet_stats.GetTotalsForDay(self.days_active)
-    return _TableQueryResult(columns=[{
+    return _TableQueryResult(
+      columns=[{
         "text": "Label", "type":"string"
       }, {
         "text": "Value", "type": "number"
       }],
-                            rows=[[label, value] for label, value
-                                  in totals.items()],
-                            type="table")
+      rows=[[label, value] for label, value
+            in totals.items()],
+      type="table")
 
 
+AVAILABLE_METRICS_LIST: List[Metric]
 AVAILABLE_METRICS_LIST = [
     ClientResourceUsageMetric(
         "Mean User CPU Rate", lambda records_list:
@@ -161,7 +163,9 @@ class Grrafana(object):
   def __init__(self) -> None:
     """Initializes a new GRRafana HTTP server instance."""
     self._url_map = werkzeug_routing.Map([
-        werkzeug_routing.Rule("/", endpoint=self._OnRoot, methods=["GET"]),
+        werkzeug_routing.Rule("/",
+                              endpoint=self._OnRoot,
+                              methods=["GET"]),
         werkzeug_routing.Rule("/search",
                               endpoint=self._OnSearch,
                               methods=["POST"]),
@@ -192,7 +196,7 @@ class Grrafana(object):
     """Fetches available resource usage metrics.
 
     Depending on the type of request Grafana is issuing, this method returns
-    either available client resource usage metrics from the constant 
+    either available client resource usage metrics from the constant
     AVAILABLE_METRICS, or possible values for a defined Grafana variable."""
     if "type" in request.json:
       # Grafana request issued on Panel > Queries page. Grafana expects the

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -87,7 +87,8 @@ class Metric(abc.ABC):
     """Initializes a new metric."""
     self._name = name
 
-  def GetName(self) -> str:
+  @property
+  def name(self) -> str:
     """Returns the name of the metric."""
     return self._name
 
@@ -185,7 +186,7 @@ for metric_name_fn, metric_extract_fn in client_statistics_names_fns:
                                 n_days)
     )
 AVAILABLE_METRICS_BY_NAME = {
-    metric.GetName(): metric for metric in AVAILABLE_METRICS_LIST
+    metric.name: metric for metric in AVAILABLE_METRICS_LIST
 }
 
 

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -153,7 +153,7 @@ AVAILABLE_METRICS_DICT = {
 
 class Grrafana(object):
   """GRRafana HTTP server instance.
-  
+
   A full description of all endpoints implemented within this HTTP
   server can be found in:
   https://github.com/simPod/grafana-json-datasource#api."""
@@ -190,7 +190,7 @@ class Grrafana(object):
 
   def _OnSearch(self, request: JSONRequest) -> JSONResponse:
     """Fetches available resource usage metrics.
-    
+
     Depending on the type of request Grafana is issuing, this method returns
     either available client resource usage metrics from the constant 
     AVAILABLE_METRICS, or possible values for a defined Grafana variable."""
@@ -209,7 +209,7 @@ class Grrafana(object):
 
   def _OnQuery(self, request: JSONRequest) -> JSONResponse:
     """Retrieves datapoints for Grafana.
-    
+
     Given a client ID as a Grafana variable and targets (resource usages),
     returns datapoints in a format Grafana can interpret."""
     json_data = request.json
@@ -219,7 +219,6 @@ class Grrafana(object):
         for target in requested_targets
     ]
     response = [t._asdict() for t in targets_with_datapoints]
-    print(response)
     return JSONResponse(response=response)
 
   def _OnAnnotations(self, request: JSONRequest) -> JSONResponse:
@@ -244,22 +243,6 @@ def main(argv: Any) -> None:
   config.CONFIG.AddContext(contexts.GRRAFANA_CONTEXT,
                            "Context applied when running GRRafana server.")
   server_startup.Init()
-  # AVAILABLE_METRICS_LIST.extend([
-  #     ClientsStatisticsMetric(
-  #         f"OS Platform Breakdown - {n_days} Day Active",
-  #         data_store.REL_DB.CountClientPlatformsByLabel, n_days)
-  #     for n_days in [1, 7, 14, 30]
-  # ])
-  # AVAILABLE_METRICS_LIST.extend([
-  #     ClientsStatisticsMetric(
-  #         f"OS Release Version Breakdown - {n_days} Day Active",
-  #         data_store.REL_DB.CountClientPlatformReleasesByLabel, n_days)
-  #     for n_days in [1, 7, 14, 30]
-  # ])
-  # global AVAILABLE_METRICS_DICT
-  # AVAILABLE_METRICS_DICT = {
-  #     metric.name: metric for metric in AVAILABLE_METRICS_LIST
-  # }
   fleetspeak_connector.Init()
   werkzeug_serving.run_simple("127.0.0.1",
                               5000,

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -149,6 +149,12 @@ AVAILABLE_METRICS_LIST.extend([
         data_store.REL_DB.CountClientPlatformReleasesByLabel(buckets), n_days)
     for n_days in _FLEET_BREAKDOWN_DAY_BUCKETS
 ])
+AVAILABLE_METRICS_LIST.extend([
+    ClientsStatisticsMetric(
+        f"Client Version Strings - {n_days} Day Active", lambda buckets:
+        data_store.REL_DB.CountClientVersionStringsByLabel(buckets), n_days)
+    for n_days in _FLEET_BREAKDOWN_DAY_BUCKETS
+])
 AVAILABLE_METRICS_DICT = {
     metric.name: metric for metric in AVAILABLE_METRICS_LIST
 }

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -6,7 +6,7 @@ import collections
 import dateutil
 import json
 import os
-from typing import Any, Callable, cast, Dict, List, Tuple, Iterable
+from typing import Any, Callable, Dict, List, NamedTuple, Tuple
 
 from fleetspeak.src.server.proto.fleetspeak_server import resource_pb2
 from google.protobuf import timestamp_pb2
@@ -38,10 +38,21 @@ flags.DEFINE_bool(
 
 _Datapoint = Tuple[float, int]
 _Datapoints = List[_Datapoint]
-_TargetWithDatapoints = collections.namedtuple("TargetWithDatapoints",
-                                               ["target", "datapoints"])
-_TableQueryResult = collections.namedtuple("TableQueryResult",
-                                           ["columns", "rows", "type"])
+
+
+class _TargetWithDatapoints(NamedTuple):
+  """A tuple that represents a processed resource usage data query."""
+
+  target: str
+  datapoints: _Datapoints
+
+
+class _TableQueryResult(NamedTuple):
+  """A tuple that represents a processed client statistics query."""
+
+  columns: List[Dict[str, str]]
+  rows: List[List[Any]]
+  type: str
 
 
 class JSONRequest(werkzeug_wrappers_json.JSONMixin, werkzeug_wrappers.Request):
@@ -76,6 +87,8 @@ class Metric(ABC):
 
 
 class ClientResourceUsageMetric(Metric):
+  """A metric that reprsents resource usage data for a single client,
+  fetched from Fleetspeak database."""
 
   def __init__(self, name: str, record_values_extract_fn: Callable) -> None:
     super().__init__(name)

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -277,10 +277,8 @@ class GrrafanaTest(absltest.TestCase):
         _TEST_CLIENT_RESOURCE_USAGE_RECORD_2
     ])
     with mock.patch.object(fleetspeak_connector, "CONN", conn):
-      self.assertRaises(KeyError,
-                        self.client.post,
-                        "/query",
-                        json=_TEST_INVALID_TARGET_QUERY)
+      with self.assertRaises(KeyError):
+        self.client.post("/query", json=_TEST_INVALID_TARGET_QUERY)
 
   def testClientsStatisticsMetric(self):
     REL_DB = _MockDatastoreReturningPlatformFleetStats(

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -246,6 +246,9 @@ class GrrafanaTest(absltest.TestCase):
     expected_res.extend([
         f"OS Release Version Breakdown - {n_days} Day Active"
         for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS])
+    expected_res.extend([
+        f"Client Version Strings - {n_days} Day Active"
+        for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS])
     self.assertListEqual(response.json, expected_res)
 
   def testClientResourceUsageMetricQuery(self):

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -68,18 +68,20 @@ _TEST_CLIENT_RESOURCE_USAGE_RECORD_2 = {
 }
 _TEST_CLIENT_BREAKDOWN_STATS = FleetStats(
     day_buckets=grrafana._FLEET_BREAKDOWN_DAY_BUCKETS,
-    label_counts={1:  {"foo-label": {"bar-os": 3, "bar2-os": 4},
+    label_counts={1:  {"foo-label": {"bar-os": 3, "baz-os": 4},
                        "bar-label": {"bar-os": 5, "foo-os": 1}},
-                  7:  {"foo-label": {"bar-os": 6, "bar2-os": 5},
+                  7:  {"foo-label": {"bar-os": 6, "baz-os": 5},
                        "bar-label": {"bar-os": 5, "foo-os": 2}},
-                  14: {"foo-label": {"bar-os": 6, "bar2-os": 5},
-                       "bar-label": {"bar-os": 5, "foo-os": 2}},
-                  30: {"foo-label": {"bar-os": 6, "bar2-os": 5},
-                       "bar-label": {"bar-os": 5, "foo-os": 2}}},
-    total_counts={1:  {"bar-os": 8, "bar2-os": 4, "foo-os": 1},
-                  7:  {"bar-os": 11, "bar2-os": 5, "foo-os": 2},
-                  14: {"bar-os": 11, "bar2-os": 5, "foo-os": 2},
-                  30: {"bar-os": 11, "bar2-os": 5, "foo-os": 2}}
+                  14: {"foo-label": {"bar-os": 6, "baz-os": 5},
+                       "bar-label": {"bar-os": 5, "foo-os": 2},
+                       "baz-label": {"bar-os":1}},
+                  30: {"foo-label": {"bar-os": 6, "baz-os": 5},
+                       "bar-label": {"bar-os": 5, "foo-os": 2},
+                       "baz-label": {"bar-os": 3, "foo-os": 1}}},
+    total_counts={1:  {"bar-os": 8, "baz-os": 4, "foo-os": 1},
+                  7:  {"bar-os": 11, "baz-os": 5, "foo-os": 2},
+                  14: {"bar-os": 12, "baz-os": 5, "foo-os": 2},
+                  30: {"bar-os": 14, "baz-os": 5, "foo-os": 3}}
 )
 _TEST_VALID_RUD_QUERY = {
     'app': 'dashboard',
@@ -284,7 +286,13 @@ class GrrafanaTest(absltest.TestCase):
     with mock.patch.object(data_store, "REL_DB", REL_DB):
       valid_response = self.client.post("/query", json=_TEST_VALID_CLIENT_STATS_QUERY)
       self.assertEqual(200, valid_response.status_code)
-      self.assertEqual(valid_response.json, [])
+      expected_res = [{
+        'columns': [{'text': 'Label', 'type': 'string'},
+                    {'text': 'Value', 'type': 'number'}],
+        'rows':    [['bar-os', 11], ['baz-os', 5], ['foo-os', 2]],
+        'type':    'table'
+      }]
+      self.assertEqual(valid_response.json, expected_res)
 
 
 class timeToProtoTimestampTest(absltest.TestCase):

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -181,6 +181,14 @@ class GrrafanaTest(absltest.TestCase):
         "Max System CPU Rate",
         "Mean Resident Memory MB",
         "Max Resident Memory MB",
+        "OS Platform Breakdown - 1 Day Active",
+        "OS Platform Breakdown - 7 Day Active",
+        "OS Platform Breakdown - 14 Day Active",
+        "OS Platform Breakdown - 30 Day Active",
+        "OS Release Version Breakdown - 1 Day Active",
+        "OS Release Version Breakdown - 7 Day Active",
+        "OS Release Version Breakdown - 14 Day Active",
+        "OS Release Version Breakdown - 30 Day Active",
     ])
 
   def testQuery(self):
@@ -209,7 +217,7 @@ class GrrafanaTest(absltest.TestCase):
         _TEST_CLIENT_RESOURCE_USAGE_RECORD_2
     ])
     with mock.patch.object(fleetspeak_connector, "CONN", conn):
-      self.assertRaises(NameError,
+      self.assertRaises(KeyError,
                         self.client.post,
                         "/query",
                         json=_TEST_INVALID_TARGET_QUERY)

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -168,22 +168,22 @@ class GrrafanaTest(absltest.TestCase):
                                     'target': ''
                                 })
     self.assertEqual(200, response.status_code)
-    self.assertListEqual(response.json, [
+
+    expected_res = [
         "Mean User CPU Rate",
         "Max User CPU Rate",
         "Mean System CPU Rate",
         "Max System CPU Rate",
         "Mean Resident Memory MB",
-        "Max Resident Memory MB",
-        "OS Platform Breakdown - 1 Day Active",
-        "OS Platform Breakdown - 7 Day Active",
-        "OS Platform Breakdown - 14 Day Active",
-        "OS Platform Breakdown - 30 Day Active",
-        "OS Release Version Breakdown - 1 Day Active",
-        "OS Release Version Breakdown - 7 Day Active",
-        "OS Release Version Breakdown - 14 Day Active",
-        "OS Release Version Breakdown - 30 Day Active",
-    ])
+        "Max Resident Memory MB"
+    ]
+    expected_res.extend([
+        f"OS Platform Breakdown - {n_days} Day Active"
+        for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS])
+    expected_res.extend([
+        f"OS Release Version Breakdown - {n_days} Day Active"
+        for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS])
+    self.assertListEqual(response.json, expected_res)
 
   def testClientResourceUsageMetricQuery(self):
     conn = _MockConnReturningRecords([


### PR DESCRIPTION
This PR extends GRRafana HTTP server introduced in #832 by adding new metrics that can be fetched.
These new metrics are the ones that appear in GRR's Statistics page (for reference, you can check out one of the metrics fetched within this page [here](https://github.com/google/grr/blob/0e03976c5c5b694c210c0f392581364ddefa1f4b/grr/server/grr_response_server/gui/api_plugins/report_plugins/client_report_plugins.py#L194)).

The metrics introduced to the server (and Grafana, in turn) are:
- OS Release Version Breakdown
- OS Platform Breakdown
- Client Version

All metrics are available in the interface for 1, 7, 14 and 30 days, and are shown in a table format (similar to the way it currently is in the Statistics page within GRR AdminUI).

In order to support this new metric (which unlike Client Load Stats in #859, which must be provided with a GRR Client ID), we GRRafana to support multiple types of metrics. So we have introduced the abstract Metric class to encapsulate the appropriate logic.

Note that this PR may make the different [cron jobs](https://github.com/google/grr/blob/0e03976c5c5b694c210c0f392581364ddefa1f4b/grr/server/grr_response_server/flows/cron/system.py#L82) that build [`FleetStats`](https://github.com/google/grr/blob/b2969c7ed6f5c6e62919fa66625d992e7b5e0b34/grr/server/grr_response_server/fleet_utils.py#L29) objects and push them to the datastore obsolete. As Grafana issues a request to GRRafana, the latter will call [`CountClientPlatformReleasesByLabel`](https://github.com/google/grr/blob/9a96b96bec76fd06e4f43e3a46cb7450c06e4b88/grr/server/grr_response_server/databases/db.py#L1071) (for example) the build the corresponding `FleetStats` object that will encapsulate the data. Then GRRafana will process it and send it back to Grafana.

Also note that in a future PR, we'd like to cache the results of the queries within GRRafana, as they may get quite time consuming with many labels and data.