### PR TITLE
Productionized GRRafana 

### DIFF
--- a/grr/server/grr_response_server/bin/grr_server.py
+++ b/grr/server/grr_response_server/bin/grr_server.py
@@ -18,6 +18,7 @@ from grr_response_core.config import server as config_server
 from grr_response_server import server_startup
 from grr_response_server.bin import fleetspeak_frontend
 from grr_response_server.bin import frontend
+from grr_response_server.bin import grrafana
 from grr_response_server.bin import worker
 from grr_response_server.gui import admin_ui
 
@@ -29,7 +30,7 @@ flags.DEFINE_bool(
     help="Print the GRR server version number and exit immediately.")
 
 flags.DEFINE_string("component", None,
-                    "Component to start: [frontend|admin_ui|worker].")
+                    "Component to start: [frontend|admin_ui|worker|grrafana].")
 
 
 def main(argv):
@@ -60,6 +61,10 @@ def main(argv):
   # Start as an AdminUI.
   elif flags.FLAGS.component.startswith("admin_ui"):
     admin_ui.main([argv])
+
+  # Start as GRRafana.
+  elif flags.FLAGS.component.startswith("grrafana"):
+    grrafana.main([argv])
 
   # Raise on invalid component.
   else:

--- a/grr/test/grr_response_test/lib/self_contained_components.py
+++ b/grr/test/grr_response_test/lib/self_contained_components.py
@@ -392,6 +392,9 @@ def StartServerProcesses(
         _StartComponent(
             "grr_response_server.bin.worker",
             Args()),
+        _StartComponent(
+            "grr_response_server.bin.grrafana",
+            Args()),
     ]
 
 


### PR DESCRIPTION
Added start up configurations to make GRRafana HTTP server a component of GRR Response Server.
Note that I only added configs where Fleetspeak is enabled, as GRRafana can only be used on a FS-based setup (no legacy).