### PR TITLE
Fix error in queryFlowResults functionality

### DIFF
--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
@@ -1,0 +1,28 @@
+import { ObservableInput, OperatorFunction, ObservedValueOf, pipe, EMPTY } from 'rxjs';
+import { concatMap, tap } from 'rxjs/operators';
+
+/** TODO */
+export function queuedExhaustMap<T, O extends ObservableInput<any>> (
+  project: (value: T, index: number) => O
+): OperatorFunction<T, ObservedValueOf<O>> {
+
+  function recordLastRequest(value: T): void {
+
+  }
+  function isLastRequest(value: T): boolean {
+    return true;
+  }
+
+  return pipe(
+    tap((value) => {
+      recordLastRequest(value);
+    }),
+    concatMap((value: T, index: number) => {
+      if (isLastRequest(value)) {
+        return project(value, index);
+      } else {
+        return EMPTY;
+      }
+    }),
+  );
+}

--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
@@ -1,24 +1,43 @@
 import { ObservableInput, OperatorFunction, ObservedValueOf, pipe, EMPTY } from 'rxjs';
 import { concatMap, tap } from 'rxjs/operators';
 
-/** TODO */
+class NotImplementedError extends Error { };
+
+class RequestTracker<T> {
+  lastValue?: T;
+  isLastValueSet = false;
+
+  recordLast(value: T): void {
+    this.lastValue = value;
+    this.isLastValueSet = true;
+  }
+
+  shouldProcess(value: T): boolean {
+    return this.isLastValueSet && this.lastValue === value;
+  }
+}
+
+/**
+ * Similar to exhaustMap, but buffers the specified number of most recent source values
+ * in a queue of limited size. The source values that are not discarded are projected to
+ * Observables and merged in the output Observable in a serialized fashion, waiting for
+ * each one to complete before merging the next.
+ */
 export function queuedExhaustMap<T, O extends ObservableInput<any>> (
-  project: (value: T, index: number) => O
+  project: (value: T, index: number) => O, queueSize: 1 = 1
 ): OperatorFunction<T, ObservedValueOf<O>> {
-
-  function recordLastRequest(value: T): void {
-
+  if (queueSize !== 1) {
+    throw new NotImplementedError('Queue size different than 1 is not implemented yet.');
   }
-  function isLastRequest(value: T): boolean {
-    return true;
-  }
+
+  const requestTracker = new RequestTracker<T>();
 
   return pipe(
     tap((value) => {
-      recordLastRequest(value);
+      requestTracker.recordLast(value);
     }),
     concatMap((value: T, index: number) => {
-      if (isLastRequest(value)) {
+      if (requestTracker.shouldProcess(value)) {
         return project(value, index);
       } else {
         return EMPTY;

--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
@@ -22,6 +22,8 @@ class RequestTracker<T> {
  * in a queue of limited size. The source values that are not discarded are projected to
  * Observables and merged in the output Observable in a serialized fashion, waiting for
  * each one to complete before merging the next.
+ *
+ * TODO: Currently only queue of size 1 is supported.
  */
 export function queuedExhaustMap<T, O extends ObservableInput<any>> (
   project: (value: T, index: number) => O, queueSize: 1 = 1

--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
@@ -23,7 +23,7 @@ class RequestTracker<T> {
  * Observables and merged in the output Observable in a serialized fashion, waiting for
  * each one to complete before merging the next.
  *
- * TODO: Currently only queue of size 1 is supported.
+ * Currently only queue of size 1 is supported.
  */
 export function queuedExhaustMap<T, O extends ObservableInput<any>> (
   project: (value: T, index: number) => O, queueSize: 1 = 1

--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
@@ -47,8 +47,6 @@ function tagByIndex<V>(indexTracker: SingleIndexTracker) {
  * endlessly and faster than their corresponding inner Observables can complete, this will
  * result in memory issues as inner Observables amass in an unbounded buffer waiting for
  * their turn to be subscribed to.
- * - If the source produces values faster than this operation discards them, no values will
- * be emitted.
  * - Currently only queue of size 1 is supported.
  */
 export function queuedExhaustMap<V, O extends ObservableInput<any>> (

--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map.ts
@@ -11,12 +11,12 @@ interface RequestTracker<T> {
 class SingleIndexTracker implements RequestTracker<number> {
   private lastIndex = -1;
 
-  recordLastTag(tag: number): void {
-    this.lastIndex = tag;
+  recordLastTag(index: number): void {
+    this.lastIndex = index;
   }
 
-  shouldProcess(thisTag: number): boolean {
-    return this.lastIndex === thisTag;
+  shouldProcess(thisIndex: number): boolean {
+    return this.lastIndex === thisIndex;
   }
 }
 
@@ -42,10 +42,14 @@ function tagByIndex<V>(indexTracker: SingleIndexTracker) {
  * Observables and merged in the output Observable in a serialized fashion, waiting for
  * each one to complete before merging the next.
  *
- * Important notes:
- * - Currently only queue of size 1 is supported.
+ * Warnings:
+ * - The implementation uses concatMap and shares its weaknesses: if source values arrive
+ * endlessly and faster than their corresponding inner Observables can complete, this will
+ * result in memory issues as inner Observables amass in an unbounded buffer waiting for
+ * their turn to be subscribed to.
  * - If the source produces values faster than this operation discards them, no values will
  * be emitted.
+ * - Currently only queue of size 1 is supported.
  */
 export function queuedExhaustMap<V, O extends ObservableInput<any>> (
   project: (value: V, index: number) => O, queueSize: 1 = 1

--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map_test.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map_test.ts
@@ -3,7 +3,7 @@ import { queuedExhaustMap } from './queued_exhaust_map';
 import { delay } from 'rxjs/operators';
 import { fakeAsync, tick } from '@angular/core/testing';
 
-fdescribe('queuedExhaustMap', () => {
+describe('queuedExhaustMap', () => {
   it('shouldn\'t discard anything if there is just one element (queue size 1)', () => {
     const valuePassed = 'dummy value';
 

--- a/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map_test.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/queued_exhaust_map_test.ts
@@ -1,0 +1,61 @@
+import { of, from, Observable } from 'rxjs';
+import { queuedExhaustMap } from './queued_exhaust_map';
+import { delay } from 'rxjs/operators';
+import { fakeAsync, tick } from '@angular/core/testing';
+
+fdescribe('queuedExhaustMap', () => {
+  it('shouldn\'t discard anything if there is just one element (queue size 1)', () => {
+    const valuePassed = 'dummy value';
+
+    const singleValue$ = of(valuePassed).pipe(
+      queuedExhaustMap((value) => {
+        return of(value);
+      }, 1),
+    );
+
+    const processedValues = getProcessedValues(singleValue$);
+    expect(processedValues).toEqual([valuePassed]);
+  });
+
+  it('shouldn\'t discard anything if there are no concurrent elements (queue size 1)', () => {
+    const repeatTimes = 10;
+    const sentValues = Array(repeatTimes).map((_value, index) => index);
+
+    const manyValues$ = from(sentValues).pipe(
+      queuedExhaustMap((value) => {
+        return of(value);
+      }, 1),
+    );
+
+    const processedValues = getProcessedValues(manyValues$);
+    expect(processedValues).toEqual(sentValues);
+  });
+
+  it('should discard everything but the last concurrent element (queue size 1)', fakeAsync(() => {
+    const blockTimeMs = 1000;
+
+    const manyValuesWithDelay$ = of('initial', 'discarded1', 'discarded2', 'lastSaved').pipe(
+      queuedExhaustMap((value) => {
+        return of(value).pipe(
+          delay(blockTimeMs),
+        );
+      }, 1),
+    );
+
+    const processedValues = getProcessedValues(manyValuesWithDelay$);
+
+    tick(blockTimeMs);
+    expect(processedValues).toEqual(['initial']);
+
+    tick(blockTimeMs);
+    expect(processedValues).toEqual(['initial', 'lastSaved']);
+  }));
+});
+
+function getProcessedValues<T>(observable$: Observable<T>) {
+  const processedValues = Array();
+  observable$.subscribe((value) => {
+    processedValues.push(value)
+  });
+  return processedValues;
+}

--- a/grr/server/grr_response_server/gui/ui/store/client_page_facade.ts
+++ b/grr/server/grr_response_server/gui/ui/store/client_page_facade.ts
@@ -358,8 +358,13 @@ export class ClientPageStore extends ComponentStore<ClientPageState> {
       obs$ => obs$.pipe(
         takeUntil(this.selectedClientIdChanged$),
         withLatestFrom(this.selectedClientId$),
+        // Below we are grouping the requests by flowId, tag and type, and
+        // for each group we use a queuedExhaustMap with queue size 1 to send http request
+        // for results.
+        // TODO: Think about how we should split the code so it's cleaner
+        // TODO: Add tests to ensure the intended functionality
         groupBy(([query, clientId]) => {
-          return query; // TODO: Group by flowId, tag and type 
+          return [query.flowId, query.withTag, query.withType].join('-');
         }),
         mergeMap(group$ => group$.pipe(
           queuedExhaustMap(([query, clientId]) => {

--- a/grr/server/grr_response_server/gui/ui/store/client_page_facade_test.ts
+++ b/grr/server/grr_response_server/gui/ui/store/client_page_facade_test.ts
@@ -3,9 +3,9 @@ import {ConfigService} from '@app/components/config/config';
 import {ApiClient, ApiClientApproval, ApiFlow, ApiFlowState, ApiScheduledFlow, ApproverSuggestion} from '@app/lib/api/api_interfaces';
 import {HttpApiService} from '@app/lib/api/http_api_service';
 import {Client, ClientApproval} from '@app/lib/models/client';
-import {FlowListEntry, flowListEntryFromFlow, FlowState, ScheduledFlow} from '@app/lib/models/flow';
+import {FlowListEntry, flowListEntryFromFlow, FlowState, ScheduledFlow, FlowResultsQuery} from '@app/lib/models/flow';
 import {newClient, newFlowDescriptorMap, newFlowListEntry} from '@app/lib/models/model_test_util';
-import {ClientPageFacade} from '@app/store/client_page_facade';
+import {ClientPageFacade, uniqueTagForQuery} from '@app/store/client_page_facade';
 import {initTestEnvironment, removeUndefinedKeys} from '@app/testing';
 import {of, Subject} from 'rxjs';
 
@@ -13,6 +13,7 @@ import {ConfigFacade} from './config_facade';
 import {ConfigFacadeMock, mockConfigFacade} from './config_facade_test_util';
 import {UserFacade} from './user_facade';
 import {mockUserFacade, UserFacadeMock} from './user_facade_test_util';
+import { delay } from 'rxjs/operators';
 
 initTestEnvironment();
 
@@ -406,6 +407,81 @@ describe('ClientPageFacade', () => {
        // Initial, then first fetched, then query flow results.
        expect(numCalls).toBe(3);
      }));
+
+  it('only discards late concurrent queries that originate from identical flows', fakeAsync(() => {
+    const delayMs = 10;
+    const apiFlowTemplate = {
+      clientId: 'C.1234',
+      lastActiveAt: '999000',
+      startedAt: '123000',
+      creator: 'rick',
+      name: 'ListProcesses',
+      state: ApiFlowState.RUNNING,
+    };
+    const queryTemplate = {
+      offset: 0,
+      count: 1,
+    };
+
+    const flowId1 = '1';
+    const flowId2 = '2';
+    const flowId3 = '3';
+
+    const flowList = [
+      {
+        ...apiFlowTemplate,
+        flowId: flowId1,
+      },
+      {
+        ...apiFlowTemplate,
+        flowId: flowId2,
+      },
+      {
+        ...apiFlowTemplate,
+        flowId: flowId3,
+      },
+    ];
+
+    clientPageFacade.flowListEntries$.subscribe();
+
+    httpApiService.listFlowsForClient =
+        jasmine.createSpy('listFlowsForClient')
+            .and.callFake(() => of(flowList));
+    tick(1);
+
+    httpApiService.listResultsForFlow = jasmine.createSpy('listResultsForFlow').and.callFake(() => {
+      return of([]).pipe(
+        delay(delayMs),
+      );
+    });
+
+    const queryFlow1 = {
+      ...queryTemplate,
+      flowId: flowId1,
+    };
+    const queryFlow2 = {
+      ...queryTemplate,
+      flowId: flowId2,
+    };
+    const queryFlow3 = {
+      ...queryTemplate,
+      flowId: flowId3,
+    };
+
+    clientPageFacade.queryFlowResults(queryFlow1);
+    clientPageFacade.queryFlowResults(queryFlow1); // discarded
+
+    clientPageFacade.queryFlowResults(queryFlow2);
+    clientPageFacade.queryFlowResults(queryFlow2); // discarded
+
+    clientPageFacade.queryFlowResults(queryFlow3);
+    clientPageFacade.queryFlowResults(queryFlow3); // discarded
+
+    tick(3 * delayMs);
+    discardPeriodicTasks();
+
+    expect(httpApiService.listResultsForFlow).toHaveBeenCalledTimes(3);
+  }));
 
   it('calls the API on startFlow', () => {
     clientPageFacade.startFlowConfiguration('ListProcesses');
@@ -859,5 +935,69 @@ describe('ClientPageFacade', () => {
     });
 
     apiSuggestApprovers$.next([{username: 'bar'}, {username: 'baz'}]);
+  });
+});
+
+describe('uniqueTagForQuery', () => {
+  const defaultQuery = {
+    flowId: 'someId',
+    withType: 'someType',
+    withTag: 'someTag',
+    offset: 1,
+    count: 1,
+  };
+
+  it('should produce the same tags for the same flowId, withType, withTag', () => {
+    const firstQuery: FlowResultsQuery = {
+      ...defaultQuery,
+      offset: 1,
+      count: 1,
+    };
+
+    const secondQuery: FlowResultsQuery = {
+      ...defaultQuery,
+      offset: 2,
+      count: 2,
+    };
+
+    expect(uniqueTagForQuery(firstQuery)).toBe(uniqueTagForQuery(secondQuery));
+  });
+
+  it('should produce different tags for different flowId or withType or withTag', () => {
+    const differentId = {
+      ...defaultQuery,
+      flowId: 'otherId',
+    };
+
+    const differentType = {
+      ...defaultQuery,
+      withType: 'otherType',
+    };
+
+    const differentTag = {
+      ...defaultQuery,
+      withTag: 'otherTag',
+    };
+
+    expect(uniqueTagForQuery(differentId)).not.toBe(uniqueTagForQuery(defaultQuery));
+    expect(uniqueTagForQuery(differentType)).not.toBe(uniqueTagForQuery(defaultQuery));
+    expect(uniqueTagForQuery(differentTag)).not.toBe(uniqueTagForQuery(defaultQuery));
+  });
+
+  it('should encode the separator', () => {
+    const noSpecialCharacters = defaultQuery;
+    const hasSpecialCharacters = uniqueTagForQuery(noSpecialCharacters);
+
+    const composedQuery = {
+      ...noSpecialCharacters,
+      flowId: hasSpecialCharacters,
+      withType: hasSpecialCharacters,
+      withTag: hasSpecialCharacters,
+    };
+    const composedEncoding = uniqueTagForQuery(composedQuery);
+
+    // If the second encoding contains the first one, then the special
+    // separator character used in the first encoding was not properly encoded.
+    expect(composedEncoding.includes(hasSpecialCharacters)).toBeFalse();
   });
 });


### PR DESCRIPTION
The old queryFlowResults implementation would discard requests for more data if another one is currently in progress, even if the new requests are coming from different flows. This caused only the first flow which requests results to get them. 

The new implementation groups requests by flows so that different flows don't affect each other. Additionaly, within the same group, it effectively creates a queue of size 1 for any pending requests, which ensures that the last request that was made will always be satisfied.