### PR TITLE
Added server and port configurations for GRRafana server

### DIFF
--- a/grr/core/grr_response_core/config/server.py
+++ b/grr/core/grr_response_core/config/server.py
@@ -282,6 +282,15 @@ config_lib.DEFINE_integer(
     "If the average network usage per client becomes "
     "greater than this limit, the hunt gets stopped.")
 
+# GRRafana HTTP Server settings.
+config_lib.DEFINE_string("GRRafana.server",
+                         default="localhost",
+                         help="The GRRafana server address.")
+
+config_lib.DEFINE_integer("GRRafana.port",
+                          default=5000,
+                          help="The GRRafana server port.")
+
 # Fleetspeak server-side integration flags.
 config_lib.DEFINE_string(
     "Server.fleetspeak_message_listen_address", "",

--- a/grr/core/grr_response_core/config/server.py
+++ b/grr/core/grr_response_core/config/server.py
@@ -283,7 +283,7 @@ config_lib.DEFINE_integer(
     "greater than this limit, the hunt gets stopped.")
 
 # GRRafana HTTP Server settings.
-config_lib.DEFINE_string("GRRafana.server",
+config_lib.DEFINE_string("GRRafana.bind",
                          default="localhost",
                          help="The GRRafana server address.")
 

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -297,8 +297,9 @@ def main(argv: Any) -> None:
                            "Context applied when running GRRafana server.")
   server_startup.Init()
   fleetspeak_connector.Init()
-  werkzeug_serving.run_simple(
-      "127.0.0.1", 5000, Grrafana(), use_debugger=True, use_reloader=True)
+  werkzeug_serving.run_simple(config.CONFIG["GRRafana.server"],
+                              config.CONFIG["GRRafana.port"],
+                              Grrafana())
 
 
 if __name__ == "__main__":

--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -297,7 +297,7 @@ def main(argv: Any) -> None:
                            "Context applied when running GRRafana server.")
   server_startup.Init()
   fleetspeak_connector.Init()
-  werkzeug_serving.run_simple(config.CONFIG["GRRafana.server"],
+  werkzeug_serving.run_simple(config.CONFIG["GRRafana.bind"],
                               config.CONFIG["GRRafana.port"],
                               Grrafana())
 


### PR DESCRIPTION
Made the server and port of GRRafana server configurable. For reference, this is similar to how the [default crash limit](https://github.com/google/grr/blob/0e03976c5c5b694c210c0f392581364ddefa1f4b/grr/server/grr_response_server/rdfvalues/hunts.py#L83) of hunts [are configured](https://github.com/google/grr/blob/fe2563069b0a8c6fdea3fe24a3c938c16391a5e3/grr/core/grr_response_core/config/server.py#L246).

I do have one small question though - do we want to let these settings be set up during `grr_config_updater initialize` as well, similar to the way the [MySQL port](https://github.com/google/grr/blob/fe2563069b0a8c6fdea3fe24a3c938c16391a5e3/grr/server/grr_response_server/bin/config_updater.py#L127) is set up?