### PR TITLE
Added Last Active Clients advanced statistics to Grafana Source Server

### DIFF
--- a/grr/server/grr_response_server/bin/grrafana.py
+++ b/grr/server/grr_response_server/bin/grrafana.py
@@ -118,9 +118,9 @@ class ClientResourceUsageMetric(Metric):
     self._record_values_extract_fn = record_values_extract_fn
 
   # Note: return type error issues at python/mypy#3915, python/typing#431
-  def ProcessQuery(
+  def ProcessQuery(  # type: ignore[override]
       self,
-      req: JSONRequest) -> _TargetWithDatapoints:  # type: ignore[override]
+      req: JSONRequest) -> _TargetWithDatapoints:
     client_id = req["scopedVars"]["ClientID"]["value"]
     start_range_ts = TimeToProtoTimestamp(req["range"]["from"])
     end_range_ts = TimeToProtoTimestamp(req["range"]["to"])
@@ -151,8 +151,8 @@ class ClientsStatisticsMetric(Metric):
     self._days_active = days_active
 
   # Note: return type error issues at python/mypy#3915, python/typing#431
-  def ProcessQuery(
-      self, req: JSONRequest) -> _TableQueryResult:  # type: ignore[override]
+  def ProcessQuery(  # type: ignore[override]
+                   self, req: JSONRequest) -> _TableQueryResult:
     fleet_stats = self._get_fleet_stats_fn(_FLEET_BREAKDOWN_DAY_BUCKETS)
     totals = fleet_stats.GetTotalsForDay(self._days_active)
     return _TableQueryResult(

--- a/grr/server/grr_response_server/bin/grrafana_test.py
+++ b/grr/server/grr_response_server/bin/grrafana_test.py
@@ -304,6 +304,10 @@ class GrrafanaTest(absltest.TestCase):
         f"Client Version Strings - {n_days} Day Active"
         for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS
     ])
+    expected_res.extend([
+        f"Client Last Active - {n_days} days active"
+        for n_days in grrafana._LAST_ACTIVE_DAY_BUCKETS
+    ])
     self.assertListEqual(response.json, expected_res)
 
   def testClientResourceUsageMetricQuery(self):


### PR DESCRIPTION
Added another metric type to the Grafana Source Server (initially presented in #832).
The code is not neat, which is mainly due to the fact it uses the legacy graphs' database and its API. This will need to be changed once we get rid of this database.