### PR TITLE
Changed datasource of Fleetspeak Grafana dashboard

### DIFF
--- a/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_for_use/fleetspeak.json
+++ b/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_for_use/fleetspeak.json
@@ -67,7 +67,7 @@
           },
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -163,7 +163,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -259,7 +259,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -365,7 +365,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -530,7 +530,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -652,7 +652,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -758,7 +758,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -854,7 +854,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -950,7 +950,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -1125,7 +1125,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -1247,7 +1247,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -1343,7 +1343,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -1439,7 +1439,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -1614,7 +1614,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -1736,7 +1736,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,
@@ -1832,7 +1832,7 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "fleetspeak",
+          "datasource": "grr-server",
           "description": null,
           "editable": true,
           "error": false,

--- a/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_to_generate/fleetspeak.dashboard.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/fleetspeak_enabled_setup/dashboards_to_generate/fleetspeak.dashboard.py
@@ -1,6 +1,6 @@
 from grafanalib.core import Alert, AlertCondition, Dashboard, Graph, Heatmap, LowerThan, OP_AND, Row, RTYPE_SUM, Target, TimeRange, YAxes, YAxis, SECONDS_FORMAT, BYTES_FORMAT
 from grr_grafanalib_dashboards.util import add_data_source
-from grr_grafanalib_dashboards.config import ACTIVE_PROCESSES_ALERTING_CONDITION
+from grr_grafanalib_dashboards.config import ACTIVE_PROCESSES_ALERTING_CONDITION, GRAFANA_DATA_SOURCE
 
 dashboard = Dashboard(
   title="Fleetspeak Servers Dashboard",
@@ -260,4 +260,4 @@ dashboard = Dashboard(
   ]
 ).auto_panel_ids()
 
-dashboard = add_data_source(dashboard, "fleetspeak")
+dashboard = add_data_source(dashboard, GRAFANA_DATA_SOURCE)


### PR DESCRIPTION
Changed the datasource from `fleetspeak` to `grr-server`, so that users don't need to set up two different [Grafana datasources](https://grafana.com/docs/grafana/latest/datasources/).
This closes [this discussion](https://github.com/google/grr-doc/pull/132#discussion_r534102231) on [google/grr-doc](https://github.com/google/grr-doc).