### PR TITLE
Rename GRRafana to Grafana Source Server

### DIFF
--- a/grr/core/grr_response_core/config/contexts.py
+++ b/grr/core/grr_response_core/config/contexts.py
@@ -36,7 +36,7 @@ POOL_CLIENT_CONTEXT = config_lib.DEFINE_context("PoolClient Context")
 WORKER_CONTEXT = config_lib.DEFINE_context("Worker Context")
 FS_FRONTEND_CONTEXT = config_lib.DEFINE_context("FleetspeakFrontend Context")
 BENCHMARK_CONTEXT = config_lib.DEFINE_context("Benchmark Context")
-GRRAFANA_CONTEXT = config_lib.DEFINE_context("GRRafana Context")
+GRAFANA_SOURCE_SERVER_CONTEXT = config_lib.DEFINE_context("Grafana Source Server Context")
 
 # Client building contexts.
 CLIENT_BUILD_CONTEXT = config_lib.DEFINE_context("ClientBuilder Context")

--- a/grr/core/grr_response_core/config/server.py
+++ b/grr/core/grr_response_core/config/server.py
@@ -284,10 +284,10 @@ config_lib.DEFINE_integer(
 
 # GRRafana HTTP Server settings.
 config_lib.DEFINE_string(
-    "GRRafana.bind", default="localhost", help="The GRRafana server address.")
+    "GrafanaSourceServer.bind", default="localhost", help="The Grafana Source Server address.")
 
 config_lib.DEFINE_integer(
-    "GRRafana.port", default=5000, help="The GRRafana server port.")
+    "GrafanaSourceServer.port", default=5000, help="The Grafana Source Server port.")
 
 # Fleetspeak server-side integration flags.
 config_lib.DEFINE_string(

--- a/grr/core/grr_response_core/config/server.py
+++ b/grr/core/grr_response_core/config/server.py
@@ -282,7 +282,7 @@ config_lib.DEFINE_integer(
     "If the average network usage per client becomes "
     "greater than this limit, the hunt gets stopped.")
 
-# GRRafana HTTP Server settings.
+# Grafana Source HTTP Server settings.
 config_lib.DEFINE_string(
     "GrafanaSourceServer.bind", default="localhost", help="The Grafana Source Server address.")
 

--- a/grr/server/grr_response_server/bin/grafana_source_server.py
+++ b/grr/server/grr_response_server/bin/grafana_source_server.py
@@ -189,8 +189,8 @@ AVAILABLE_METRICS_BY_NAME = {
 }
 
 
-class Grrafana(object):
-  """GRRafana HTTP server instance.
+class GrafanaSourceServer(object):
+  """Grafana Source HTTP server instance.
 
   A full description of all endpoints implemented within this HTTP
   server can be found in:
@@ -278,15 +278,15 @@ def main(argv: Any) -> None:
   del argv  # Unused.
 
   if flags.FLAGS.version:
-    print(f"GRRafana server {config_server.VERSION['packageversion']}")
+    print(f"Grafana Source Server {config_server.VERSION['packageversion']}")
     return
 
-  config.CONFIG.AddContext(contexts.GRRAFANA_CONTEXT,
-                           "Context applied when running GRRafana server.")
+  config.CONFIG.AddContext(contexts.GRAFANA_SOURCE_SERVER_CONTEXT,
+                           "Context applied when running Grafana Source Server.")
   server_startup.Init()
   fleetspeak_connector.Init()
-  werkzeug_serving.run_simple(config.CONFIG["GRRafana.bind"],
-                              config.CONFIG["GRRafana.port"], Grrafana())
+  werkzeug_serving.run_simple(config.CONFIG["grafana_source_server.bind"],
+                              config.CONFIG["grafana_source_server.port"], GrafanaSourceServer())
 
 
 if __name__ == "__main__":

--- a/grr/server/grr_response_server/bin/grafana_source_server.py
+++ b/grr/server/grr_response_server/bin/grafana_source_server.py
@@ -285,8 +285,8 @@ def main(argv: Any) -> None:
                            "Context applied when running Grafana Source Server.")
   server_startup.Init()
   fleetspeak_connector.Init()
-  werkzeug_serving.run_simple(config.CONFIG["grafana_source_server.bind"],
-                              config.CONFIG["grafana_source_server.port"], GrafanaSourceServer())
+  werkzeug_serving.run_simple(config.CONFIG["GrafanaSourceServer.bind"],
+                              config.CONFIG["GrafanaSourceServer.port"], GrafanaSourceServer())
 
 
 if __name__ == "__main__":

--- a/grr/server/grr_response_server/bin/grafana_source_server_test.py
+++ b/grr/server/grr_response_server/bin/grafana_source_server_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Lint as: python3
-"""Unittest for GRRafana HTTP server."""
+"""Unittest for Grafana Source HTTP Server."""
 import copy
 
 from absl import app
@@ -12,7 +12,7 @@ from google.protobuf import timestamp_pb2
 
 from grr_response_server import data_store
 from grr_response_server import fleetspeak_connector
-from grr_response_server.bin import grrafana
+from grr_response_server.bin import grafana_source_server
 from grr_response_server.fleet_utils import FleetStats
 
 from fleetspeak.src.server.proto.fleetspeak_server import admin_pb2
@@ -67,7 +67,7 @@ _TEST_CLIENT_RESOURCE_USAGE_RECORD_2 = {
     "max_resident_memory_mib": 59
 }
 _TEST_CLIENT_BREAKDOWN_STATS = FleetStats(
-    day_buckets=grrafana._FLEET_BREAKDOWN_DAY_BUCKETS,
+    day_buckets=grafana_source_server._FLEET_BREAKDOWN_DAY_BUCKETS,
     label_counts={
         1: {
             "foo-label": {
@@ -267,13 +267,14 @@ def _MockDatastoreReturningPlatformFleetStats(client_fleet_stats):
   return rel_db
 
 
-class GrrafanaTest(absltest.TestCase):
-  """Test the GRRafana HTTP server."""
+class GrafanaSourceServerTest(absltest.TestCase):
+  """Test the Grafana Source HTTP Server."""
 
   def setUp(self):
-    super(GrrafanaTest, self).setUp()
+    super(GrafanaSourceServerTest, self).setUp()
     self.client = werkzeug_test.Client(
-        application=grrafana.Grrafana(), response_wrapper=grrafana.JSONResponse)
+        application=grafana_source_server.GrafanaSourceServer(),
+        response_wrapper=grafana_source_server.JSONResponse)
 
   def testRoot(self):
     response = self.client.get("/")
@@ -294,15 +295,15 @@ class GrrafanaTest(absltest.TestCase):
     ]
     expected_res.extend([
         f"OS Platform Breakdown - {n_days} Day Active"
-        for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS
+        for n_days in grafana_source_server._FLEET_BREAKDOWN_DAY_BUCKETS
     ])
     expected_res.extend([
         f"OS Release Version Breakdown - {n_days} Day Active"
-        for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS
+        for n_days in grafana_source_server._FLEET_BREAKDOWN_DAY_BUCKETS
     ])
     expected_res.extend([
         f"Client Version Strings - {n_days} Day Active"
-        for n_days in grrafana._FLEET_BREAKDOWN_DAY_BUCKETS
+        for n_days in grafana_source_server._FLEET_BREAKDOWN_DAY_BUCKETS
     ])
     self.assertListEqual(response.json, expected_res)
 
@@ -361,10 +362,10 @@ class TimeToProtoTimestampTest(absltest.TestCase):
 
   def testTimeToProtoTimestamp(self):
     self.assertEqual(
-        grrafana.TimeToProtoTimestamp(_START_RANGE_TIMESTAMP),
+        grafana_source_server.TimeToProtoTimestamp(_START_RANGE_TIMESTAMP),
         timestamp_pb2.Timestamp(seconds=1597328417, nanos=(158 * 1000000)))
     self.assertEqual(
-        grrafana.TimeToProtoTimestamp(_END_RANGE_TIMESTAMP),
+        grafana_source_server.TimeToProtoTimestamp(_END_RANGE_TIMESTAMP),
         timestamp_pb2.Timestamp(seconds=1597770958, nanos=(761 * 1000000)))
 
 

--- a/grr/server/grr_response_server/bin/grr_server.py
+++ b/grr/server/grr_response_server/bin/grr_server.py
@@ -62,7 +62,7 @@ def main(argv):
   elif flags.FLAGS.component.startswith("admin_ui"):
     admin_ui.main([argv])
 
-  # Start as GRRafana.
+  # Start as Grafana Source Server.
   elif flags.FLAGS.component.startswith("grafana_source_server"):
     grafana_source_server.main([argv])
 

--- a/grr/server/grr_response_server/bin/grr_server.py
+++ b/grr/server/grr_response_server/bin/grr_server.py
@@ -18,7 +18,7 @@ from grr_response_core.config import server as config_server
 from grr_response_server import server_startup
 from grr_response_server.bin import fleetspeak_frontend
 from grr_response_server.bin import frontend
-from grr_response_server.bin import grrafana
+from grr_response_server.bin import grafana_source_server
 from grr_response_server.bin import worker
 from grr_response_server.gui import admin_ui
 
@@ -30,7 +30,7 @@ flags.DEFINE_bool(
     help="Print the GRR server version number and exit immediately.")
 
 flags.DEFINE_string("component", None,
-                    "Component to start: [frontend|admin_ui|worker|grrafana].")
+                    "Component to start: [frontend|admin_ui|worker|grafana_source_server].")
 
 
 def main(argv):
@@ -63,8 +63,8 @@ def main(argv):
     admin_ui.main([argv])
 
   # Start as GRRafana.
-  elif flags.FLAGS.component.startswith("grrafana"):
-    grrafana.main([argv])
+  elif flags.FLAGS.component.startswith("grafana_source_server"):
+    grafana_source_server.main([argv])
 
   # Raise on invalid component.
   else:

--- a/grr/server/grr_response_server/distro_entry.py
+++ b/grr/server/grr_response_server/distro_entry.py
@@ -45,6 +45,6 @@ def AdminUI():
   app.run(admin_ui.main)
 
 
-def Grrafana():
-  from grr_response_server.bin import grrafana
-  app.run(grrafana.main)
+def GrafanaSourceServer():
+  from grr_response_server.bin import grafana_source_server
+  app.run(grafana_source_server.main)

--- a/monitoring/grafana/grr_grafanalib_dashboards/config.py
+++ b/monitoring/grafana/grr_grafanalib_dashboards/config.py
@@ -3,11 +3,11 @@ from grr_grafanalib_dashboards import reusable_panels
 # The data source names are specified after Grafana is set up
 # and it can be visited at localhost:3000.
 # In GRR Monitoring docs, we suggest naming the data sources "grr-server"
-# and "grrafana" respectively, but if it's not the case, change it here.
+# and "grafana-source-server" respectively, but if it's not the case, change it here.
 # For reference, take a look at the docs here:
-# https://grr-doc.readthedocs.io/en/latest/maintaining-and-tuning/monitoring.html#example-visualization-and-alerting-setup
+# https://grr-doc.readthedocs.io/en/latest/maintaining-and-tuning/monitoring.html#grafana-setup
 GRAFANA_DATA_SOURCE = "grr-server"
-CLIENT_LOAD_STATS_DATA_SOURCE = "grrafana"
+CLIENT_LOAD_STATS_DATA_SOURCE = "grafana-source-server"
 
 # An alert will be fired if the number of active processes (of any
 # GRR server component) is below this number.


### PR DESCRIPTION
As discussed with @mbushkov in [this discussion](https://github.com/google/grr/pull/891#discussion_r530193704), the name GRRafana introduced in #832 is nice but gets increasingly confusing with Grafana. So we change the name to `Grafana Source Server` across the codebase (and to the docs later on).