### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,21 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
+      - run: black --check . || true
+      - run: codespell || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: mypy --install-types --non-interactive . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/grr/core/executables/python_hacks/modify_network.py
+++ b/grr/core/executables/python_hacks/modify_network.py
@@ -5,6 +5,8 @@
 import platform
 import re
 
+from grr.client.grr_response_client import client_utils_common
+
 
 def NetshStaticIp(interface,
                   ip=u'127.0.0.9',

--- a/grr/core/executables/python_hacks/shutdown_host.py
+++ b/grr/core/executables/python_hacks/shutdown_host.py
@@ -4,6 +4,8 @@
 
 import platform
 
+from grr.client.grr_response_client import client_utils_common 
+
 tested_versions = ['xp', 'vista', '2008', '2003']
 cmd = 'cmd'
 args = ['/c', '%SystemRoot%\\System32\\shutdown.exe', '/s', '/f']


### PR DESCRIPTION
Output: https://github.com/cclauss/grr/actions

Fixes undefined name [`client_utils_common`](https://github.com/google/grr/search?q=client_utils_common)

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./grr/core/executables/python_hacks/shutdown_host.py:23:47: F821 undefined name 'client_utils_common'
    stdout, stderr, exit_status, time_taken = client_utils_common.Execute(
                                              ^
./grr/core/executables/python_hacks/modify_network.py:31:9: F821 undefined name 'client_utils_common'
  res = client_utils_common.Execute(
        ^
./grr/core/executables/python_hacks/modify_network.py:51:13: F821 undefined name 'client_utils_common'
      res = client_utils_common.Execute(
            ^
./grr/core/executables/python_hacks/modify_network.py:66:9: F821 undefined name 'client_utils_common'
  res = client_utils_common.Execute(
        ^
./grr/core/executables/python_hacks/modify_network.py:95:13: F821 undefined name 'client_utils_common'
      res = client_utils_common.Execute(
            ^
```
Also see #937