### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/appveyor/windows_templates/build_windows_templates.py
+++ b/appveyor/windows_templates/build_windows_templates.py
@@ -372,7 +372,7 @@ class WindowsTemplateBuilder(object):
   def _CleanupInstall(self):
     """Cleanup from any previous installer enough for _CheckInstallSuccess."""
 
-    logging.info("Stoping service %s.", self.service_name)
+    logging.info("Stopping service %s.", self.service_name)
     subprocess.check_call(["sc", "stop", self.service_name])
 
     if args.build_msi:

--- a/grr/client/grr_response_client/unprivileged/communication.py
+++ b/grr/client/grr_response_client/unprivileged/communication.py
@@ -273,7 +273,7 @@ class SubprocessServer(Server):
     Args:
       args_factory: Function which takes a channel and returns the args to run
         the server subprocess (as required by subprocess.Popen).
-      extra_file_descriptors: Extra file desctiptors to map to the subprocess.
+      extra_file_descriptors: Extra file descriptors to map to the subprocess.
     """
     self._args_factory = args_factory
     self._process = None  # type: Optional[subprocess.Popen]

--- a/grr/client/grr_response_client/unprivileged/windows/sandbox_lib.py
+++ b/grr/client/grr_response_client/unprivileged/windows/sandbox_lib.py
@@ -345,5 +345,5 @@ class Sandbox:
     self.desktop_name = _GetFullDesktopName(h_window_station, h_desktop)
 
   def Close(self) -> None:
-    """Releases the sate of the sandbox."""
+    """Releases the state of the sandbox."""
     self._exit_stack.close()

--- a/grr/client/grr_response_client/unprivileged/windows/sandbox_test.py
+++ b/grr/client/grr_response_client/unprivileged/windows/sandbox_test.py
@@ -35,7 +35,7 @@ def setUpModule():
       sys.prefix,
       # Path to the Python installation
       sys.base_prefix,
-      # Path to the souce code tree
+      # Path to the source code tree
       _SourceCodeBaseDir(),
   }
 
@@ -45,8 +45,8 @@ def setUpModule():
   if hasattr(sys, "real_prefix"):
     read_only_paths.add(getattr(sys, "real_prefix"))
 
-  # For permissions to be set correctly on the directory treees, inhertiance
-  # needs to be enabled. Otherwise, permissions don't propage recursively.
+  # For permissions to be set correctly on the directory treees, inheritance
+  # needs to be enabled. Otherwise, permissions don't propagate recursively.
   # This enables inheritance on all directory trees recursively.
   # Since this is a very slow operation, directories are processed in parallel.
 

--- a/grr/client/grr_response_client/vfs_handlers/files.py
+++ b/grr/client/grr_response_client/vfs_handlers/files.py
@@ -197,7 +197,7 @@ class File(vfs_base.VFSHandler):
       # files and directories using the file listing property, we must force
       # treating raw devices as files.
       elif re.match(r"/*\\\\.\\[^\\]+\\?$", self.path) is not None:
-        # Special case windows devices cant seek to the end so just lie about
+        # Special case windows devices can't seek to the end so just lie about
         # the size
         self.size = 0x7fffffffffffffff
 

--- a/grr/client/grr_response_client/windows/process.py
+++ b/grr/client/grr_response_client/windows/process.py
@@ -153,7 +153,7 @@ class Process(object):
     self.min_addr = si.lpMinimumApplicationAddress
 
   def Close(self):
-    """Relases all resources this instance is using."""
+    """Releases all resources this instance is using."""
     if self.h_process is not None:
       if self.h_process == self._existing_handle:
         # Not owned by this instance.

--- a/grr/core/grr_response_core/lib/parsers/linux_pam_parser_test.py
+++ b/grr/core/grr_response_core/lib/parsers/linux_pam_parser_test.py
@@ -48,9 +48,9 @@ ETC_PAMD_TELNET = b"""
   testing.so module arguments  # Comments
 """
 ETC_PAMD_EXTERNAL = b"""
-password substack nonexistant
+password substack nonexistent
 auth optional testing.so
-@include /external/nonexistant
+@include /external/nonexistent
 """
 
 TELNET_ONLY_CONFIG = {'/etc/pam.d/telnet': ETC_PAMD_TELNET}

--- a/grr/core/grr_response_core/lib/rdfvalues/artifacts.py
+++ b/grr/core/grr_response_core/lib/rdfvalues/artifacts.py
@@ -255,7 +255,7 @@ class Artifact(rdf_structs.RDFProtoStruct):
   # These labels represent the full set of labels that an Artifact can have.
   # This set is tested on creation to ensure our list of labels doesn't get out
   # of hand.
-  # Labels are used to logicaly group Artifacts for ease of use.
+  # Labels are used to logically group Artifacts for ease of use.
 
   ARTIFACT_LABELS = {
       "Antivirus": "Antivirus related artifacts, e.g. quarantine files.",

--- a/grr/core/grr_response_core/lib/util/cache_test.py
+++ b/grr/core/grr_response_core/lib/util/cache_test.py
@@ -174,7 +174,7 @@ class WithLimitedCallFrequencyTest(absltest.TestCase):
 
     self.assertEqual(mock_fn.call_count, 10)
 
-  # TODO(user): add a test case for a cace when non-hashable arguments are
+  # TODO(user): add a test case for a cache when non-hashable arguments are
   # passed.
 
 

--- a/grr/server/grr_response_server/checks/pam_test.py
+++ b/grr/server/grr_response_server/checks/pam_test.py
@@ -140,14 +140,14 @@ class PamConfigTests(checks_test_lib.HostCheckTest):
     """Test we detect when PAM ssh service doesn't deny auth by default."""
     pam_good = {"/etc/pam.d/ssh": "auth include other", "/etc/pam.d/other": ""}
     pam_bad = {
-        "/etc/pam.d/ssh": "auth include non-existant",
-        "/etc/pam.d/other": "password include /tmp/non-existant"
+        "/etc/pam.d/ssh": "auth include non-existent",
+        "/etc/pam.d/other": "password include /tmp/non-existent"
     }
     # Check the detection case.
     sym = "Found: PAM configuration refers to files outside of /etc/pam.d."
     found = [
-        "/etc/pam.d/ssh -> /etc/pam.d/non-existant",
-        "/etc/pam.d/other -> /tmp/non-existant"
+        "/etc/pam.d/ssh -> /etc/pam.d/non-existent",
+        "/etc/pam.d/other -> /tmp/non-existent"
     ]
     results = self.RunChecks(
         self.GenFileData("PamConfig", pam_bad, parser=self.parser))

--- a/grr/server/grr_response_server/gui/api_call_router.py
+++ b/grr/server/grr_response_server/gui/api_call_router.py
@@ -136,7 +136,7 @@ class RouterMethodMetadata(object):
     /api/clients/<client_id>/last-ip would return ["client_id"].
 
     For GET requests the returned list will also include optional
-    query paramerters. For example, /api/clients?query=... will
+    query parameters. For example, /api/clients?query=... will
     return ["query"]. For non-GET HTTP methods no optional parameters will
     be included into the result.
 

--- a/grr/server/grr_response_server/gui/selenium_tests/dir_refresh_test.py
+++ b/grr/server/grr_response_server/gui/selenium_tests/dir_refresh_test.py
@@ -138,7 +138,7 @@ class DirRefreshTest(gui_test_lib.GRRSeleniumTest):
         "~ td.proto_value")
 
   # NOTE: sometimes with headless Chrome the button doesn't get
-  # reenabled.
+  # re-enabled.
   @flaky
   def testRefreshButtonGetsDisabledWhileUpdateIsRunning(self):
     self.Open("/#/clients/C.0000000000000001/vfs/fs/os/c/")

--- a/grr/server/grr_response_server/gui/ui/components/flow_args_form/collect_multiple_files_form_helpers/size_condition_test.ts
+++ b/grr/server/grr_response_server/gui/ui/components/flow_args_form/collect_multiple_files_form_helpers/size_condition_test.ts
@@ -49,7 +49,7 @@ describe('SizeCondition component', () => {
        expect(maxField.nativeElement.value).toBe('20 MB');
      });
 
-  it('exposes form values and shows currect hint when only minimum file size field is filled',
+  it('exposes form values and shows correct hint when only minimum file size field is filled',
      async () => {
        const fixture = TestBed.createComponent(SizeCondition);
        const loader = TestbedHarnessEnvironment.loader(fixture);
@@ -75,7 +75,7 @@ describe('SizeCondition component', () => {
                '10,000,000 bytes, inclusive');
      });
 
-  it('exposes form values and shows currect hint when both fields are filled',
+  it('exposes form values and shows correct hint when both fields are filled',
      async () => {
        const fixture = TestBed.createComponent(SizeCondition);
        const loader = TestbedHarnessEnvironment.loader(fixture);

--- a/grr/server/grr_response_server/gui/ui/lib/polling.ts
+++ b/grr/server/grr_response_server/gui/ui/lib/polling.ts
@@ -13,7 +13,7 @@ interface PollArgs<T> {
  *
  * This function returns an Observable that, while being subscribed to:
  *
- * 1) Calls pollEffect() everytime `pollOn` emits. Use timer() for regular
+ * 1) Calls pollEffect() every time `pollOn` emits. Use timer() for regular
  *    polling.
  * 2) Passes through `selector`.
  *

--- a/grr/server/grr_response_server/output_plugins/bigquery_plugin.py
+++ b/grr/server/grr_response_server/output_plugins/bigquery_plugin.py
@@ -251,7 +251,7 @@ class BigQueryOutputPlugin(output_plugin.OutputPlugin):
                                                  None) or "STRING"
 
         # For protos with RDF types we need to do some more checking to properly
-        # covert types.
+        # convert types.
         if hasattr(type_info, "original_proto_type_name"):
           if type_info.original_proto_type_name in [
               "RDFDatetime", "RDFDatetimeSeconds"

--- a/grr/server/grr_response_server/rdfvalues/objects.py
+++ b/grr/server/grr_response_server/rdfvalues/objects.py
@@ -341,7 +341,7 @@ class PathInfo(rdf_structs.RDFProtoStruct):
     super().__init__(*args, **kwargs)
     _ValidatePathComponents(self.components)
 
-  # TODO(hanuszczak): Find a reliable way to make sure that noone ends up with
+  # TODO(hanuszczak): Find a reliable way to make sure that no one ends up with
   # incorrect `PathInfo` (a one that is both root and non-directory). Simple
   # validation in a constructor has two flaws:
   #

--- a/grr/test/grr_response_test/test_data/checks/data/dpkg.out
+++ b/grr/test/grr_response_test/test_data/checks/data/dpkg.out
@@ -7,9 +7,9 @@ ii  acpi-support-base               0.140-5                   all          scrip
 ii  acpid                           1:2.0.16-1+deb7u1         amd64        Advanced Configuration and Power Interface event daemon
 ii  adduser                         3.113+nmu3                all          add and remove users and groups
 ii  apt                             0.9.7.9                   amd64        commandline package manager
-ii  apt-utils                       0.9.7.9                   amd64        package managment related utility programs
+ii  apt-utils                       0.9.7.9                   amd64        package management related utility programs
 ii  aptitude                        0.6.8.2-1                 amd64        terminal-based package manager
-ii  aptitude-common                 0.6.8.2-1                 all          architecture indepedent files for the aptitude package manager
+ii  aptitude-common                 0.6.8.2-1                 all          architecture independent files for the aptitude package manager
 ii  base-files                      7.1wheezy1                amd64        Debian base system miscellaneous files
 ii  base-passwd                     3.5.26                    amd64        Debian base system master password and group files
 ii  bash                            4.2+dfsg-0.1              amd64        GNU Bourne Again SHell
@@ -57,7 +57,7 @@ ii  kmod                            9-3                       amd64        tools
 ii  kpartx                          0.4.9+git0.4dfdaf2b-6     amd64        create device mappings for partitions
 ii  libacl1:amd64                   2.2.51-8                  amd64        Access control list shared library
 ii  libapt-inst1.5:amd64            0.9.7.9                   amd64        deb package format runtime library
-ii  libapt-pkg4.12:amd64            0.9.7.9                   amd64        package managment runtime library
+ii  libapt-pkg4.12:amd64            0.9.7.9                   amd64        package management runtime library
 ii  libattr1:amd64                  1:2.4.46-8                amd64        Extended attribute shared library
 ii  libblkid1:amd64                 2.20.1-5.3                amd64        block device id library
 ii  libboost-iostreams1.49.0        1.49.0-3.2                amd64        Boost.Iostreams Library


### PR DESCRIPTION
```
codespell --skip="*.js" \
 --ignore-words-list="atleast,ba,crypted,datas,doubleclick,filetest,fle,fo,fpr,hist,invokable,msdos,nd,sur,usera,vew"
```
https://github.com/codespell-project/codespell

Discovered via #936 