### PR TITLE
Fix: `pytest` version ,`soft_unicode` from `markupsafe` error on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Upload installers to GitHub artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: centos-installersf
+          name: centos-installers
           path: gcs_upload_dir/
           retention-days: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test
         run: |
           source "${HOME}/INSTALL/bin/activate"
-          pip install pytest-xdist==2.2.1 pytest==6.2.5 Markupsafe==2.0.1
+          pip install pytest-xdist==2.2.1 pytest==6.2.5
           # We have 4 vCPUs available, but only use 3 here to avoid timeouts like
           # https://ci.appveyor.com/project/grr/grr-ia94e/builds/20483467/messages ,
           # which happen when tests stall.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test
         run: |
           source "${HOME}/INSTALL/bin/activate"
-          pip install pytest-xdist==2.2.1
+          pip install pytest-xdist==2.2.1 pytest==6.2.5 Markupsafe==2.0.1
           # We have 4 vCPUs available, but only use 3 here to avoid timeouts like
           # https://ci.appveyor.com/project/grr/grr-ia94e/builds/20483467/messages ,
           # which happen when tests stall.
@@ -142,7 +142,7 @@ jobs:
       - name: Upload installers to GitHub artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: centos-installers
+          name: centos-installersf
           path: gcs_upload_dir/
           retention-days: 1
 

--- a/grr/server/setup.py
+++ b/grr/server/setup.py
@@ -185,6 +185,10 @@ setup_args = dict(
         VERSION.get("Version", "packagedepends"),
         "grr-response-core==%s" % VERSION.get("Version", "packagedepends"),
         "Jinja2==2.11.3",
+        # TODO: This should be 2.0.1
+        # If the version of MarkupSafe with Jinja2 dependency is greater than 2.0.1 an issue occurs.
+        # Therefore, we are currently fixing the version to 2.0.1,
+        # but it will be fixed later when the issue is resolved.
         "MarkupSafe==2.0.1",
         "pexpect==4.8.0",
         "portpicker==1.3.1",

--- a/grr/server/setup.py
+++ b/grr/server/setup.py
@@ -185,7 +185,7 @@ setup_args = dict(
         VERSION.get("Version", "packagedepends"),
         "grr-response-core==%s" % VERSION.get("Version", "packagedepends"),
         "Jinja2==2.11.3",
-        # TODO: This should be 2.0.1
+        # TODO: This should be 2.1
         # If the version of MarkupSafe with Jinja2 dependency is greater than 2.0.1 an issue occurs.
         # Therefore, we are currently fixing the version to 2.0.1,
         # but it will be fixed later when the issue is resolved.

--- a/grr/server/setup.py
+++ b/grr/server/setup.py
@@ -185,6 +185,7 @@ setup_args = dict(
         VERSION.get("Version", "packagedepends"),
         "grr-response-core==%s" % VERSION.get("Version", "packagedepends"),
         "Jinja2==2.11.3",
+        "MarkupSafe==2.0.1",
         "pexpect==4.8.0",
         "portpicker==1.3.1",
         "prometheus_client==0.8.0",


### PR DESCRIPTION
Hello, everyone in the community! 🙂

Based on @Tati1701 good work (#969), I create new PR for reflect my suggestion.
Please refer to this link for discussions with my proposal: https://github.com/google/grr/pull/969#discussion_r849424559
However, `test-ubuntu-e2e` is still not working, so it needs to be resolved by that PR or a new PR.

If you have any comments on this PR, please feel free to leave a thread! 🙌