### PR TITLE
Update: `cryptography` version `2.9.2` to `3.3.2` by issue

### DIFF
--- a/api_client/python/setup.py
+++ b/api_client/python/setup.py
@@ -64,9 +64,7 @@ setup_args = dict(
     },
     install_requires=[
         "grr_response_proto==%s" % VERSION.get("Version", "packagedepends"),
-        # TODO: This should be 3.3.2, but AppVeyor has issues with
-        # that version.
-        "cryptography==2.9.2",
+        "cryptography==3.3.2",
         "requests==2.25.1",
         "Werkzeug>=0.16.0,<=1.0.1",
     ],

--- a/grr/core/setup.py
+++ b/grr/core/setup.py
@@ -133,9 +133,7 @@ setup_args = dict(
         "sdist": Sdist,
     },
     install_requires=[
-        # TODO: This should be 3.3.2, but AppVeyor has issues with
-        # that version.
-        "cryptography==2.9.2",
+        "cryptography==3.3.2",
         "distro==1.5.0",
         "fleetspeak==0.1.9",
         "grr-response-proto==%s" % VERSION.get("Version", "packagedepends"),


### PR DESCRIPTION
Hello, everyone in the community! 🙂

We have used GRR's API in many DFIR open sources to take advantage of GRR's superior functionality.
However, in order to avoid errors in the deployment process in GRR's API,
we have limited the version of the `cryptography` module.
Currently, these restrictions are a problem at new devices or platforms and require version updates.
So I raised an issue (#967) about this, and we decided to proceed with the version update.
We will continue to monitor and improve the side effect.

I hope this PR will have a good effect on other DFIR projects.

Fixes #967 