### PR TITLE
Fix missing DLL issue Windows machines without VCRuntime

### DIFF
--- a/grr/core/grr_response_core/config/build.py
+++ b/grr/core/grr_response_core/config/build.py
@@ -139,6 +139,10 @@ a = Analysis\(
     # TODO\(https://github.com/pypa/setuptools/issues/1963\): py2_warn is
     # a workaround. Revisit in the future, whether this is needed.
     hiddenimports=CHIPSEC_IMPORTS + WINDOWS_IMPORTS + ["pkg_resources.py2_warn"],
+    # TODO: Remove this binary once PyInstaller version is updated.
+    # The binary below is needed in machines that do not have VC installed.
+    # This was patched by them in: https://github.com/pyinstaller/pyinstaller/pull/5770/files
+    binaries=[\("C:\\\\Windows\\\\System32\\\\VCRUNTIME140_1.dll", "."\)],
     hookspath=None\)
 
 # Remove some optional libraries that would be packed but serve no purpose.

--- a/grr/core/grr_response_core/config/build.py
+++ b/grr/core/grr_response_core/config/build.py
@@ -131,8 +131,10 @@ if platform.system\(\).lower\(\) == 'linux':
   CHIPSEC_IMPORTS = ["chipsec.helper.oshelper", "chipsec.helper.linux.linuxhelper"]
 
 WINDOWS_IMPORTS = []
+WINDOWS_BINARIES = []
 if platform.system\(\).lower\(\) == 'windows':
   WINDOWS_IMPORTS = ["win32process", "win32timezone"]
+  WINDOWS_BINARIES = [\("C:\\\\Windows\\\\System32\\\\VCRUNTIME140_1.dll", "."\)]
 
 a = Analysis\(
     [client_path],
@@ -142,7 +144,7 @@ a = Analysis\(
     # TODO: Remove this binary once PyInstaller version is updated.
     # The binary below is needed in machines that do not have VC installed.
     # This was patched by them in: https://github.com/pyinstaller/pyinstaller/pull/5770/files
-    binaries=[\("C:\\\\Windows\\\\System32\\\\VCRUNTIME140_1.dll", "."\)],
+    binaries=WINDOWS_BINARIES,
     hookspath=None\)
 
 # Remove some optional libraries that would be packed but serve no purpose.


### PR DESCRIPTION
This issue was fixed by PyInstaller in a newer version, but since we still use the old one we need to patch it ourselves. It can be removed as soon as we upgrade. For more information, see https://github.com/pyinstaller/pyinstaller/pull/5770/files