### PR TITLE
Update elasticsearch output plugin.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@
   or deleted.
 * Added configuration option Monitoring.http_address to specify server address
   of stats server. Default value will remain 127.0.0.1.
+* Updates elasticsearch output plugin post request to _bulk in the
+  elasticsearch api. Adds a terminating \n and content type headers for
+  application/json.
 
 ## 3.4.3.1
 

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin.py
@@ -146,7 +146,7 @@ class ElasticsearchOutputPlugin(output_plugin.OutputPlugin):
     data = "\n".join([
         "{}\n{}".format(index_command, json.Dump(event, indent=None))
         for event in events
-    ])
+    ]) + "\n"
 
     response = requests.post(
         url=self._url, verify=self._verify_https, data=data, headers=headers)

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin.py
@@ -135,9 +135,9 @@ class ElasticsearchOutputPlugin(output_plugin.OutputPlugin):
     # https://www.elastic.co/guide/en/elasticsearch/reference/7.1/docs-bulk.html
 
     if self._token:
-      headers = {"Authorization": "Basic {}".format(self._token)}
+      headers = {"Authorization": "Basic {}".format(self._token), "Content-Type": "application/json"}
     else:
-      headers = {}
+      headers = {"Content-Type": "application/json"}
 
     index_command = json.Dump({"index": {"_index": self._index}}, indent=None)
 

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
@@ -161,7 +161,7 @@ class ElasticsearchOutputPluginTest(flow_test_lib.FlowTestsBaseclass):
                      'Basic b')
     self.assertIn(
         mock_post.call_args[KWARGS]['headers']['Content-Type'],
-        ['application/json', 'application/x-ndjson']
+        ('application/json', 'application/x-ndjson')
     )
 
     bulk_pairs = self._ParseEvents(mock_post)

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
@@ -159,9 +159,9 @@ class ElasticsearchOutputPluginTest(flow_test_lib.FlowTestsBaseclass):
     self.assertFalse(mock_post.call_args[KWARGS]['verify'])
     self.assertEqual(mock_post.call_args[KWARGS]['headers']['Authorization'],
                      'Basic b')
-    self.assertTrue(
-        mock_post.call_args[KWARGS]['headers']['Content-Type'] == 'application/json' or
-        mock_post.call_args[KWARGS]['headers']['Content-Type'] == 'application/x-ndjson'
+    self.assertIn(
+        mock_post.call_args[KWARGS]['headers']['Content-Type'],
+        ['application/json', 'application/x-ndjson']
     )
 
     bulk_pairs = self._ParseEvents(mock_post)

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
@@ -75,8 +75,6 @@ class ElasticsearchOutputPluginTest(flow_test_lib.FlowTestsBaseclass):
         if not line:
             continue
         split_requests.append(json.Parse(line))
-    #update_pairs = [(split_requests[i], split_requests[i + 1])
-    #                for i in range(0, len(split_requests), 2)]
     update_pairs = []
     for i in range(0, len(split_requests), 2):
         update_pairs.append([split_requests[i], split_requests[i + 1]])

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
@@ -69,8 +69,8 @@ class ElasticsearchOutputPluginTest(flow_test_lib.FlowTestsBaseclass):
     # Elasticsearch bulk requests are line-deliminated pairs, where the first
     # line is the index command and the second is the actual document to index
     split_requests = []
-    splitRequest = request.split('\n')
-    for line in splitRequest:
+    split_request = request.split('\n')
+    for line in split_request:
         # Skip terminating newlines - which crashes json.Parse
         if not line:
             continue

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
@@ -153,6 +153,10 @@ class ElasticsearchOutputPluginTest(flow_test_lib.FlowTestsBaseclass):
     self.assertFalse(mock_post.call_args[KWARGS]['verify'])
     self.assertEqual(mock_post.call_args[KWARGS]['headers']['Authorization'],
                      'Basic b')
+    self.assertTrue(
+        mock_post.call_args[KWARGS]['headers']['Content-Type'] == 'application/json' or
+        mock_post.call_args[KWARGS]['headers']['Content-Type'] == 'application/x-ndjson'
+    )
 
     bulk_pairs = self._ParseEvents(mock_post)
     self.assertEqual(bulk_pairs[0][0]['index']['_index'], 'e')

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
@@ -66,12 +66,20 @@ class ElasticsearchOutputPluginTest(flow_test_lib.FlowTestsBaseclass):
 
   def _ParseEvents(self, patched):
     request = patched.call_args[KWARGS]['data']
-
     # Elasticsearch bulk requests are line-deliminated pairs, where the first
     # line is the index command and the second is the actual document to index
-    split_requests = [json.Parse(line) for line in request.split('\n')]
-    update_pairs = [(split_requests[i], split_requests[i + 1])
-                    for i in range(0, len(split_requests), 2)]
+    split_requests = []
+    splitRequest = request.split('\n')
+    for line in splitRequest:
+        # Skip terminating newlines - which crashes json.Parse
+        if not line:
+            continue
+        split_requests.append(json.Parse(line))
+    #update_pairs = [(split_requests[i], split_requests[i + 1])
+    #                for i in range(0, len(split_requests), 2)]
+    update_pairs = []
+    for i in range(0, len(split_requests), 2):
+        update_pairs.append([split_requests[i], split_requests[i + 1]])
 
     return update_pairs
 

--- a/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
+++ b/grr/server/grr_response_server/output_plugins/elasticsearch_plugin_test.py
@@ -199,6 +199,15 @@ class ElasticsearchOutputPluginTest(flow_test_lib.FlowTestsBaseclass):
             responses=[rdf_client.Process(pid=42)],
             patcher=mock.patch.object(requests, 'post', post))
 
+  def testPostDataTerminatingNewline(self):
+      with test_lib.ConfigOverrider({
+          'Elasticsearch.url': 'http://a',
+          'Elasticsearch.token': 'b',
+      }):
+          mock_post = self._CallPlugin(
+              plugin_args=elasticsearch_plugin.ElasticsearchOutputPluginArgs(),
+              responses=[rdf_client.Process(pid=42)])
+      self.assertTrue(mock_post.call_args[KWARGS]['data'].endswith('\n'))
 
 if __name__ == '__main__':
   app.run(test_lib.main)


### PR DESCRIPTION
Updates the elasticsearch output plugin to conform to additional requirements set by the elasticcsearch [_bulk api.](https://www.elastic.co/guide/en/elasticsearch/reference/8.3/docs-bulk.html)

>The final line of data must end with a newline character \n. Each newline character may be preceded by a carriage return \r. When sending NDJSON data to the _bulk endpoint, use a Content-Type header of application/json or application/x-ndjson.

Adds a changelog entry for the above change.

Edit: 
Added a test to ensure one of the elastic approved content type headers is used.
Added a test to ensure the post body to _bulk ends with a '\n'.

------
Closes #990 