### PR TITLE
Add Monitoring.http_address to expose Prometheus stats server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,8 @@
 * Introduced Server.grr_binaries_readonly configuration option (set to False
   by default). When set to True, binaries and python hacks can't be overriden
   or deleted.
-* Allow stats server to be TCP bound rather than the loopback device for
-  metrics export.
+* Added configuration option Monitoring.http_address to specify server address
+  of stats server. Default value will remain 127.0.0.1.
 
 ## 3.4.3.1
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
 * Introduced Server.grr_binaries_readonly configuration option (set to False
   by default). When set to True, binaries and python hacks can't be overriden
   or deleted.
+* Allow stats server to be TCP bound rather than the loopback device for
+  metrics export.
 
 ## 3.4.3.1
 

--- a/grr/core/grr_response_core/config/logging.py
+++ b/grr/core/grr_response_core/config/logging.py
@@ -48,8 +48,11 @@ config_lib.DEFINE_option(
         description="The email address to notify in an emergency.",
         default="grr-emergency@localhost"))
 
+config_lib.DEFINE_string("Monitoring.http_address", "::1",
+    "IP address for stats monitoring server.")
+
 config_lib.DEFINE_integer("Monitoring.http_port", 0,
-                          "Port for stats monitoring server.")
+    "Port for stats monitoring server.")
 
 config_lib.DEFINE_integer(
     "Monitoring.http_port_max", None,

--- a/grr/server/grr_response_server/base_stats_server.py
+++ b/grr/server/grr_response_server/base_stats_server.py
@@ -28,12 +28,14 @@ class BaseStatsServer(metaclass=abc.ABCMeta):
     port: The TCP port that the server should listen to.
   """
 
-  def __init__(self, port):
+  def __init__(self, address, port):
     """Instantiates a new BaseStatsServer.
 
     Args:
+      address: The IP address of the server to bind.
       port: The TCP port that the server should listen to.
     """
+    self.address = address
     self.port = port
 
   @abc.abstractmethod

--- a/grr/server/grr_response_server/stats_server.py
+++ b/grr/server/grr_response_server/stats_server.py
@@ -44,7 +44,7 @@ class StatsServer(base_stats_server.BaseStatsServer):
   def Start(self):
     """Start HTTPServer."""
     try:
-      self._http_server = IPv6HTTPServer(("::1", self.port), StatsServerHandler)
+      self._http_server = IPv6HTTPServer(("::", self.port), StatsServerHandler)
     except socket.error as e:
       if e.errno == errno.EADDRINUSE:
         raise base_stats_server.PortInUseError(self.port)

--- a/grr/server/grr_response_server/stats_server_test.py
+++ b/grr/server/grr_response_server/stats_server_test.py
@@ -23,7 +23,7 @@ class StatsServerTest(base_stats_server_test.StatsServerTestMixin,
                       test_lib.GRRBaseTest):
 
   def setUpStatsServer(self, port):
-    return stats_server.StatsServer(port)
+    return stats_server.StatsServer("::1", port)
 
   def testPrometheusIntegration(self):
     registry = prometheus_client.CollectorRegistry(auto_describe=True)
@@ -38,7 +38,7 @@ class StatsServerTest(base_stats_server_test.StatsServerTestMixin,
 
     with mock.patch.object(stats_server.StatsServerHandler, "registry",
                            registry):
-      server = stats_server.StatsServer(port)
+      server = stats_server.StatsServer("::1", port)
       server.Start()
       self.addCleanup(server.Stop)
       res = requests.get("http://[::1]:{}/metrics".format(port))


### PR DESCRIPTION
## Summary
Added configuration option to specify the stats server IP address to bind to. Default option will remain 127.0.0.1 loopback.

I use separate containers (Pods) for the GRR components and need the ability to expose the Prometheus  metric endpoints to  Kubernetes Services which forwards the results to a Prometheus operator. With the current setup the metrics are only accessible from within the container's local loopback device (localhost). 

Edit:

Taking @max-vogler 