### PR TITLE
Syncing recent changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned for removal
+
+Note: GRR release 3.4.7.1 is the **last release** containing the following
+features:
+
+* **Artifact parsers**. ArtifactCollector flow supports parsing collected files
+  and output of executed commands. Its parsers are not properly maintained,
+  are often outdated and fragile. We're going to convert selected parsers
+  into standalone flows and remove the artifact parsing subsystem:
+  the ArtifactCollector will always work as if "apply_parsers" arguments
+  attribute is set to False. Afterwards the "apply_parsers" attribute will be
+  deprecated completely. We will provide documentation on integrating
+  GRR and ArtifactCollector with well-maintained parsing frameworks like
+  [Plaso](https://plaso.readthedocs.io/en/latest/index.html).
+
+* **Built-in cron jobs**. Built-in cron jobs are primarily used for periodic
+  hunts. We will provide documentation on how to easily replicate the
+  current functionality using external scheduling systems (like Linux cron,
+  for example).
+
+  If your workflow depends on GRR built in cron jobs and you anticipate problems
+  when migrating it to external schedulers, please reach out to us via email
+  or GitHub.
+
+* **GRR server Debian package**. We will stop providing the GRR server Debian
+  package as the main way of distributing GRR server and client binaries.
+  Instead we will make GRR Docker image a preferred way for running GRR in a
+  demo or production environment.
+
+If your workflow depends on any of the above, please feel free reach out to
+us via [grr-users](https://groups.google.com/forum/#!forum/grr-users) Google
+Group or [GitHub](https://github.com/google/grr/issues).
+
+## [3.4.7.1] - 2023-10-23
+
 ### Added
 
 * Created a flow for collecting an identifier of the CrowdStrike agent.
+* Podman-based zero-setup development environment.
+* Added StatMultipleFiles and HashMultipleFiles flows to be used in
+  UIv2.
 
 ### Changed
 
 * Renamed AdminUI.new_hunt_wizard.default_output_plugin to
   AdminUI.new_hunt_wizard.default_output_plugins (note the "s" in the end).
   The new option accepts a comma-separated list of names.
+* Newly interrogated clients now pick up active hunts automatically.
+* Hunts workflow is now available in the new UI: creating hunts from a flow,
+  duplicating existing hunts, monitoring hunt progress and inspecting results.
 
 ### Removed
 
 * Fully removed deprecated use_tsk flag.
 * Removed deprecated plugin_args field from OutputPluginDescriptor.
-* Removed deprecated flows: FingerprintFile
+* Removed deprecated flows: FingerprintFile, KeepAlive, FingerprintFile, FindFiles, SendFile, Uninstall,
+  UpdateClient, CollectEfiHashes, DumpEfiImage.
+* Deprecated GetFile flow in favor of MultiGetFile.
+* Made FileFinder an alias to ClientFileFinder, using ClientFileFinder
+  by default everywhere. Legacy FileFinder is still available as
+  LegacyFileFinder. Fixed several inconsistencies in ClientFileFinder
+  client action. Same for RegistryFinder.
+* Removed deprecated client actions: EficheckCollectHashes, EficheckDumpImage, Uninstall, SendFile.
+* Removed "Checks" functionality.
+
+### API removed
+
+* Deprecated no-op "keep_client_alive" attribute in ApiCreateClientApprovalArgs.
+* Deprecated ListClientActionRequests API call (was no-op after Fleetspeak migration).
 
 ## [3.4.6.7] - 2023-03-22
 

--- a/grr/client/grr_response_client/client_actions/file_finder_test.py
+++ b/grr/client/grr_response_client/client_actions/file_finder_test.py
@@ -252,6 +252,19 @@ class FileFinderTest(client_test_lib.EmptyActionTest):
       except OSError:
         pass
 
+  def testBrokenLink(self):
+    """Broken links should be collected when follow_links=False."""
+    with temp.AutoTempDirPath(remove_non_empty=True) as test_dir:
+      link_path = os.path.join(test_dir, "link")
+
+      os.symlink("nowhere", link_path)
+
+      paths = [f"{test_dir}/*"]
+      results = self._RunFileFinder(paths, self.stat_action, follow_links=False)
+      relative_results = self._GetRelativeResults(results, base_path=test_dir)
+
+      self.assertIn("link", relative_results)
+
   def _PrepareTimestampedFiles(self):
     searching_path = os.path.join(self.base_path, "searching")
     test_dir = os.path.join(self.temp_dir, "times_test")

--- a/grr/client/setup.py
+++ b/grr/client/setup.py
@@ -137,7 +137,7 @@ setup_args = dict(
         "grr-response-core==%s" % VERSION.get("Version", "packagedepends"),
         "pytsk3==20230125",
         "libfsntfs-python==20230606",
-        "fleetspeak-client-bin==0.1.12",
+        "fleetspeak-client-bin==0.1.13",
     ],
     extras_require={
         # The following requirements are needed in Windows.

--- a/grr/client_builder/setup.py
+++ b/grr/client_builder/setup.py
@@ -65,7 +65,7 @@ setup_args = dict(
         "distro==1.7.0",
         "grr-response-client==%s" % VERSION.get("Version", "packagedepends"),
         "grr-response-core==%s" % VERSION.get("Version", "packagedepends"),
-        "fleetspeak-client-bin==0.1.12",
+        "fleetspeak-client-bin==0.1.13",
         "olefile==0.46",
         "PyInstaller==5.8.0",
     ],

--- a/grr/core/grr_response_core/config/artifacts.py
+++ b/grr/core/grr_response_core/config/artifacts.py
@@ -12,9 +12,6 @@ config_lib.DEFINE_list("Artifacts.artifact_dirs", [
 
 config_lib.DEFINE_list(
     "Artifacts.knowledge_base", [
-        "LinuxReleaseInfo",
-        "LinuxUserProfiles",
-        "WindowsTimezone",
     ], "List of artifacts that are collected regularly by"
     " interrogate and used for interpolation of client-side"
     " variables. Includes artifacts for all supported OSes. "

--- a/grr/core/grr_response_core/lib/parsers/linux_release_parser.py
+++ b/grr/core/grr_response_core/lib/parsers/linux_release_parser.py
@@ -139,7 +139,10 @@ class LinuxReleaseParser(parsers.MultiFileParser[rdf_protodict.Dict]):
   """Parser for Linux distribution information."""
 
   output_types = [rdf_protodict.Dict]
-  supported_artifacts = ['LinuxReleaseInfo']
+
+  # TODO: The parser has to be invoked explicitly, we should not
+  # relly on magic parsing anymore.
+  supported_artifacts = []
 
   # Multiple files exist to define a Linux distribution, some of which are more
   # accurate than others under certain circumstances. We assign a weight and

--- a/grr/core/grr_response_core/lib/rdfvalue.py
+++ b/grr/core/grr_response_core/lib/rdfvalue.py
@@ -610,12 +610,6 @@ class RDFDatetime(RDFPrimitive):
 
     return cls(round((1 - t) * start_time._value + t * end_time._value))  # pylint: disable=protected-access
 
-  @classmethod
-  def EarliestDatabaseSafeValue(cls):
-    """Returns the earliest datetime supported by all database backends."""
-    # See https://bugs.mysql.com/77232
-    return cls(1000000)
-
   def __add__(self, other):
     # TODO(hanuszczak): Disallow `float` initialization.
     if isinstance(other, (int, float)):

--- a/grr/core/grr_response_core/lib/rdfvalues/structs.py
+++ b/grr/core/grr_response_core/lib/rdfvalues/structs.py
@@ -1986,6 +1986,9 @@ class RDFProtoStruct(RDFStruct):
   # dependencies setting.
   recorded_rdf_deps = None
 
+  def __init__(self, initializer=None, **kwargs):
+    super().__init__(initializer, **kwargs)
+
   def AsPrimitiveProto(self):
     """Return an old style protocol buffer object."""
     if self.protobuf:

--- a/grr/proto/grr_response_proto/rrg.proto
+++ b/grr/proto/grr_response_proto/rrg.proto
@@ -34,6 +34,10 @@ enum Action {
   LIST_USERS = 9;
   // Get the snapshot of the entire filesystem.
   GET_FILESYSTEM_TIMELINE = 10;
+  // List network interfaces available on the system.
+  LIST_INTERFACES = 11;
+  // List filesystem mounts available on the system.
+  LIST_MOUNTS = 12;
 
   // TODO: Define more actions that should be supported.
 

--- a/grr/proto/grr_response_proto/rrg/action/list_interfaces.proto
+++ b/grr/proto/grr_response_proto/rrg/action/list_interfaces.proto
@@ -1,0 +1,14 @@
+// Copyright 2023 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+syntax = "proto3";
+
+package rrg.action.list_interfaces;
+
+import "grr_response_proto/rrg/net.proto";
+
+message Result {
+  // Information about the individual network interface.
+  rrg.net.Interface interface = 1;
+}

--- a/grr/proto/grr_response_proto/rrg/action/list_mounts.proto
+++ b/grr/proto/grr_response_proto/rrg/action/list_mounts.proto
@@ -1,0 +1,14 @@
+// Copyright 2023 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+syntax = "proto3";
+
+package rrg.action.list_mounts;
+
+import "grr_response_proto/rrg/fs.proto";
+
+message Result {
+  // Information about the individual filesystem mount.
+  rrg.fs.Mount mount = 1;
+}

--- a/grr/proto/grr_response_proto/rrg/fs.proto
+++ b/grr/proto/grr_response_proto/rrg/fs.proto
@@ -70,3 +70,13 @@ message FileExtAttr {
     // This can be an arbitrary sequence of bytes both on macOS and Linux.
     bytes value = 2;
 }
+
+// Information about a mounted filesystem.
+message Mount {
+    // Name or other identifier of the mounted device.
+    string name = 1;
+    // Path at which the mounted filesystem is available (a mount point).
+    Path path = 2;
+    // Type of the mounted filesystem (e.g. `ext4`, `ramfs`, `NTFS`).
+    string fs_type = 3;
+}

--- a/grr/proto/grr_response_proto/rrg/net.proto
+++ b/grr/proto/grr_response_proto/rrg/net.proto
@@ -91,3 +91,20 @@ message Connection {
     UdpConnection udp = 2;
   }
 }
+
+// Information about a network interface.
+message Interface {
+  // A name of the interface as reported by the system.
+  //
+  // Note that on some system (e.g. Linux), the interface may consist of pretty
+  // much arbitrary bytes and might not be compatible with Unicode. Because this
+  // is not very probable and ergonomics of using a raw `bytes` field, invalid
+  // bytes are going to be subsituted with the replacement character ("�").
+  string name = 1;
+
+  // MAC address associated with the interface.
+  MacAddress mac_address = 2;
+
+  // IP addresses associated with the interface.
+  repeated IpAddress ip_addresses = 3;
+}

--- a/grr/server/grr_response_server/artifact_test.py
+++ b/grr/server/grr_response_server/artifact_test.py
@@ -693,7 +693,6 @@ class GrrKbLinuxTest(GrrKbTest):
     with test_lib.ConfigOverrider({
         "Artifacts.knowledge_base": [
             "LinuxWtmp", "NetgroupConfiguration", "LinuxPasswdHomedirs",
-            "LinuxReleaseInfo"
         ],
         "Artifacts.netgroup_filter_regexes": ["^login$"],
         "Artifacts.netgroup_ignore_users": ["isaac"]
@@ -717,10 +716,11 @@ class GrrKbLinuxTest(GrrKbTest):
     with vfs_test_lib.FakeTestDataVFSOverrider():
       with test_lib.ConfigOverrider({
           "Artifacts.knowledge_base": [
-              "LinuxWtmp", "LinuxPasswdHomedirs", "LinuxReleaseInfo"
+              "LinuxWtmp",
+              "LinuxPasswdHomedirs",
           ],
           "Artifacts.knowledge_base_additions": [],
-          "Artifacts.knowledge_base_skip": []
+          "Artifacts.knowledge_base_skip": [],
       }):
         with test_lib.SuppressLogs():
           kb = self._RunKBI()
@@ -746,7 +746,6 @@ class GrrKbLinuxTest(GrrKbTest):
     with test_lib.ConfigOverrider({
         "Artifacts.knowledge_base": [
             "NetgroupConfiguration", "NssCacheLinuxPasswdHomedirs",
-            "LinuxReleaseInfo"
         ],
         "Artifacts.netgroup_filter_regexes": ["^doesntexist$"]
     }):

--- a/grr/server/grr_response_server/fleetspeak_connector.py
+++ b/grr/server/grr_response_server/fleetspeak_connector.py
@@ -38,7 +38,8 @@ def Init(service_client=None):
         "GRR",
         fleetspeak_message_listen_address=fleetspeak_message_listen_address,
         fleetspeak_server=fleetspeak_server,
-        threadpool_size=50)
+        threadpool_size=config.CONFIG["Threadpool.size"],
+    )
 
   label_map = {}
   for entry in config.CONFIG["Server.fleetspeak_label_map"]:

--- a/grr/server/grr_response_server/flows/general/administrative.py
+++ b/grr/server/grr_response_server/flows/general/administrative.py
@@ -662,7 +662,7 @@ class ClientStartupHandler(message_handlers.MessageHandler):
         # data
         data_store.REL_DB.WriteClientMetadata(
             client_id,
-            last_foreman=rdfvalue.RDFDatetime.EarliestDatabaseSafeValue(),
+            last_foreman=data_store.REL_DB.MinTimestamp(),
         )
 
       except db.UnknownClientError:

--- a/grr/server/grr_response_server/flows/general/administrative_test.py
+++ b/grr/server/grr_response_server/flows/general/administrative_test.py
@@ -782,7 +782,7 @@ magic_return_str = "foo(%s)"
 
   def testForemanTimeIsResetOnClientStartupInfoWrite(self):
     client_id = self.SetupClient(0)
-    reset_time = rdfvalue.RDFDatetime.EarliestDatabaseSafeValue()
+    reset_time = data_store.REL_DB.MinTimestamp()
     later_time = rdfvalue.RDFDatetime.FromSecondsSinceEpoch(3600)
 
     data_store.REL_DB.WriteClientMetadata(client_id, last_foreman=later_time)

--- a/grr/server/grr_response_server/flows/general/discovery.py
+++ b/grr/server/grr_response_server/flows/general/discovery.py
@@ -483,7 +483,7 @@ class Interrogate(flow_base.FlowBase):
     # Reset foreman rules check so active hunts can match against the new data
     data_store.REL_DB.WriteClientMetadata(
         self.client_id,
-        last_foreman=rdfvalue.RDFDatetime.EarliestDatabaseSafeValue(),
+        last_foreman=data_store.REL_DB.MinTimestamp(),
     )
 
 

--- a/grr/server/grr_response_server/flows/general/discovery_test.py
+++ b/grr/server/grr_response_server/flows/general/discovery_test.py
@@ -215,9 +215,10 @@ class TestClientInterrogate(acl_test_lib.AclTestMixin,
                                    vfs_test_lib.FakeTestDataVFSHandler):
       with test_lib.ConfigOverrider({
           "Artifacts.knowledge_base": [
-              "LinuxWtmp", "NetgroupConfiguration", "LinuxReleaseInfo"
+              "LinuxWtmp",
+              "NetgroupConfiguration",
           ],
-          "Artifacts.netgroup_filter_regexes": [r"^login$"]
+          "Artifacts.netgroup_filter_regexes": [r"^login$"],
       }):
         client_mock = action_mocks.InterrogatedClient()
         client_mock.InitializeClient()
@@ -259,9 +260,10 @@ class TestClientInterrogate(acl_test_lib.AclTestMixin,
     with vfs_test_lib.FakeTestDataVFSOverrider():
       with test_lib.ConfigOverrider({
           "Artifacts.knowledge_base": [
-              "LinuxWtmp", "NetgroupConfiguration", "LinuxReleaseInfo"
+              "LinuxWtmp",
+              "NetgroupConfiguration",
           ],
-          "Artifacts.netgroup_filter_regexes": [r"^login$"]
+          "Artifacts.netgroup_filter_regexes": [r"^login$"],
       }):
         client_mock = action_mocks.InterrogatedClient()
         client_mock.InitializeClient(version="14.4", release="Ubuntu")
@@ -680,9 +682,7 @@ class TestClientInterrogate(acl_test_lib.AclTestMixin,
 
     md = data_store.REL_DB.ReadClientMetadata(client_id)
     self.assertIsNotNone(md.last_foreman_time)
-    self.assertEqual(
-        md.last_foreman_time, rdfvalue.RDFDatetime.EarliestDatabaseSafeValue()
-    )
+    self.assertEqual(md.last_foreman_time, data_store.REL_DB.MinTimestamp())
 
 
 def _HasClientActionRequest(

--- a/grr/server/grr_response_server/gui/api_plugins/client.py
+++ b/grr/server/grr_response_server/gui/api_plugins/client.py
@@ -650,7 +650,7 @@ class ApiAddClientsLabelsHandler(api_call_handler_base.ApiCallHandler):
     # Reset foreman rules check so active hunts can match against the new data
     data_store.REL_DB.MultiWriteClientMetadata(
         client_ids,
-        last_foreman=rdfvalue.RDFDatetime.EarliestDatabaseSafeValue(),
+        last_foreman=data_store.REL_DB.MinTimestamp(),
     )
 
 

--- a/grr/server/grr_response_server/gui/api_plugins/client_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/client_test.py
@@ -151,9 +151,7 @@ class ApiAddClientsLabelsHandlerTest(api_test_lib.ApiCallHandlerTest):
 
     md = data_store.REL_DB.ReadClientMetadata(cid)
     self.assertIsNotNone(md.last_foreman_time)
-    self.assertEqual(
-        md.last_foreman_time, rdfvalue.RDFDatetime.EarliestDatabaseSafeValue()
-    )
+    self.assertEqual(md.last_foreman_time, data_store.REL_DB.MinTimestamp())
 
 
 class ApiRemoveClientsLabelsHandlerTest(api_test_lib.ApiCallHandlerTest):

--- a/grr/server/grr_response_server/gui/wsgiapp.py
+++ b/grr/server/grr_response_server/gui/wsgiapp.py
@@ -300,8 +300,13 @@ class AdminUIApp(object):
   def _HandleHomepageV2(self, request):
     """Renders GRR home page for the next-get UI (v2)."""
 
+    is_development = contexts.DEBUG_CONTEXT in config.CONFIG.context
+
     context = {
-        "is_development": contexts.DEBUG_CONTEXT in config.CONFIG.context,
+        "is_development": is_development,
+        "use_debug_bundle": is_development or request.args.get(
+            "use_debug_bundle", False
+        ),
         "is_test": contexts.TEST_CONTEXT in config.CONFIG.context,
         "analytics_id": config.CONFIG["AdminUI.analytics_id"],
     }

--- a/grr/server/setup.py
+++ b/grr/server/setup.py
@@ -200,7 +200,7 @@ setup_args = dict(
         # TODO: We currently release fleetspeak-server-bin packages
         # for Linux only.
         ':sys_platform=="linux"': [
-            "fleetspeak-server-bin==0.1.12",
+            "fleetspeak-server-bin==0.1.13",
         ],
     },
     data_files=data_files,

--- a/grr/test/grr_response_test/lib/self_contained_config_writer.py
+++ b/grr/test/grr_response_test/lib/self_contained_config_writer.py
@@ -70,6 +70,10 @@ def main(argv):
   config_lib.LoadConfig(config.CONFIG, source_server_config_path)
   config.CONFIG.SetWriteBack(_DEST_SERVER_CONFIG_PATH.value)
 
+  # Make sure to not overload the machine running the self-contained tests.
+  # Threadpool.size currently influences the size of the Fleetspeak Frontend's
+  # threadpool that handles incoming gRPC requests from Fleetspeak.
+  config.CONFIG.Set("Threadpool.size", 5)
   config.CONFIG.Set("Blobstore.implementation", "DbBlobStore")
   config.CONFIG.Set("Database.implementation", "MysqlDB")
   config.CONFIG.Set("Mysql.database", _CONFIG_MYSQL_DATABASE.value)

--- a/version.ini
+++ b/version.ini
@@ -3,7 +3,7 @@
 major = 3
 minor = 4
 revision = 7
-release = 0
+release = 1
 
 packageversion = %(major)s.%(minor)s.%(revision)spost%(release)s
 packagedepends = %(packageversion)s


### PR DESCRIPTION
* FileFinderOS bugfix for handling broken symlinks.
* Further decoupling interrogation from artifact parsers.
* Decoupling RRG protos from GRR protos.
* Updated fleetspeak-client-bin and fleetspeak-server-bin dependencies versions to 0.1.13.
* Butmping current version to 3.4.7.1.
* Adding changelog for 3.4.7.1 release.