### PR TITLE
Update build.yml (switch macOS builds to Intel macs).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           retention-days: 1
 
   build-osx:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
We do not provide M1 macs installers yet (fleetspeak-client-bin doesn't have M1 Fleetspeak binaries).