### PR TITLE
Update compose.yaml: preventing a race between building the client and waiting for it.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -55,7 +55,7 @@ services:
       # As soon as any files have been written to the /client_installer we
       # assume the service is healthy.
       test: |
-        if [[ -z "$(ls /client_installers)" ]]; then
+        if [[ -z "$(ls /client_installers/*.deb)" ]]; then
           echo "Healthckeck: GRR client installer not available"
           exit 1
         fi


### PR DESCRIPTION
grr-client container should wait until client's DEB package is available (right now it waits for any package to be there).