### PR TITLE
Fixing grpcio dependency behavior in devenv GRR container.

### DIFF
--- a/devenv/src/containers/grr/Containerfile
+++ b/devenv/src/containers/grr/Containerfile
@@ -23,11 +23,10 @@ RUN cd /grr/persist \
 
 RUN cd /grr/src \
   && . /grr/persist/venv/bin/activate \
-  && pip install \
-    -e grr/proto \
-    -e grr/core \
-    -e grr/client \
-    -e grr/client_builder \
-    -e api_client/python \
-    -e grr/server \
-    -e grr/test
+  && pip install -e grr/proto \
+  && pip install -e grr/core \
+  && pip install -e grr/client \
+  && pip install -e grr/client_builder \
+  && pip install -e api_client/python \
+  && pip install -e grr/server \
+  && pip install -e grr/test


### PR DESCRIPTION
grpcio and grpcio-tools are effectively build-only dependency for GRR, but a runtime dependency for google-cloud-pubsub. To avoid versioning conflicts, we should install our own packages with separate `pip install` calls - this allows each call to override the version of grpcio or grpcio-tools if needed. This is clearly a hack. A proper fix is to migrate from setup.py to toml files and explicitly declare grpcio and grpcio-tools as GRR's build (and not runtime) dependencies.