### PR TITLE
Bumping up artifacts archive

### DIFF
--- a/grr/core/grr_response_core/artifacts/makefile.py
+++ b/grr/core/grr_response_core/artifacts/makefile.py
@@ -14,7 +14,7 @@ def main():
   # The future direction is to depend on code in the artifact repo to replace
   # the artifact registry and validation inside GRR. We will then move to
   # depending on pypi releases rather than just importing the yaml as we do now.
-  url = "https://github.com/ForensicArtifacts/artifacts/archive/refs/tags/20220615.zip"
+  url = "https://github.com/ForensicArtifacts/artifacts/archive/refs/tags/20240303.zip"
   data = urlrequest.urlopen(url).read()
 
   zip_obj = zipfile.ZipFile(io.BytesIO(data))


### PR DESCRIPTION
This PR proposes to bump up the artifacts archive as the version currently used is dating back to June 2022.
The latest version available however is from March 2024.