### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ jobs:
   test-ubuntu:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '18'
       - name: Setup Chrome
@@ -37,7 +37,7 @@ jobs:
   build-openapi:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install
         run: |
           sudo apt install -y python3-dev python3-pip python3-venv python3-mysqldb
@@ -51,7 +51,7 @@ jobs:
           travis/build_api_documentation.sh "_openapi_artifacts/openapi_description/openapi_description.json" "_openapi_artifacts/documentation/openapi_documentation.html"
           ls -la _openapi_artifacts/*
       - name: Upload OpenAPI to GitHub artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openapi
           path: _openapi_artifacts/
@@ -60,8 +60,8 @@ jobs:
   build-ubuntu:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Set up
@@ -75,7 +75,7 @@ jobs:
           travis/build_templates.sh
           ls -la installers_dir
       - name: Upload installers to GitHub artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ubuntu-installers
           path: installers_dir/
@@ -88,7 +88,7 @@ jobs:
       DOCKER_CONTAINER: centos_64bit_container
       DOCKER_USER: grrbot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build installers
         run: |
           docker run -dit \
@@ -108,7 +108,7 @@ jobs:
           docker exec "${DOCKER_CONTAINER}" rpm -vih installers_dir/*.rpm
           ls -la installers_dir
       - name: Upload installers to GitHub artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: centos-installers
           path: installers_dir/
@@ -117,8 +117,8 @@ jobs:
   build-windows:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Build installers
@@ -131,7 +131,7 @@ jobs:
           mv -v output*/* installers_dir
           ls -la installers_dir
       - name: Upload installers to GitHub artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-installers
           path: installers_dir/
@@ -146,10 +146,10 @@ jobs:
       - build-ubuntu
       - build-windows
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download installers from GitHub artifacts
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: '*installer*'
           path: _installers
@@ -173,7 +173,7 @@ jobs:
             ${{ steps.meta.outputs.tags }}
           outputs: type=docker,dest=/tmp/grr_base_image.tar
       - name: Upload docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr_base_image
           path: /tmp/grr_base_image.tar
@@ -186,9 +186,9 @@ jobs:
     needs:
       - build-docker-image
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: grr_base_image
           path: /tmp
@@ -222,7 +222,7 @@ jobs:
           docker compose logs > /tmp/docker_compose_test.log
       - name: Upload docker compose logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docker_commpose_test_logs
           path: /tmp/docker_compose_test.log
@@ -245,9 +245,9 @@ jobs:
       - test-ubuntu
       - docker-compose-e2e-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: grr_base_image
           path: /tmp

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,11 +7,11 @@ jobs:
   build-pypi-packages:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
       - name: Build
@@ -27,49 +27,49 @@ jobs:
           python colab/setup.py --quiet sdist --formats=zip --dist-dir="/tmp/sdists"
           python api_client/python/setup.py --quiet sdist --formats=zip --dist-dir="/tmp/sdists"
       - name: Upload grr-response-proto
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-response-proto
           path: /tmp/sdists/grr-response-proto-[0-9]*.zip
           retention-days: 3          
       - name: Upload grr-response-core
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-response-core
           path: /tmp/sdists/grr-response-core-[0-9]*.zip
           retention-days: 3          
       - name: Upload grr-response-client
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-response-client
           path: /tmp/sdists/grr-response-client-[0-9]*.zip
           retention-days: 3          
       - name: Upload grr-response-client-builder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-response-client-builder
           path: /tmp/sdists/grr-response-client-builder-[0-9]*.zip
           retention-days: 3          
       - name: Upload grr-response-server
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-response-server
           path: /tmp/sdists/grr-response-server-[0-9]*.zip
           retention-days: 3              
       - name: Upload grr-response-test
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-response-test
           path: /tmp/sdists/grr-response-test-[0-9]*.zip
           retention-days: 3
       - name: Upload grr-colab
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-colab
           path: /tmp/sdists/grr-colab-[0-9]*.zip
           retention-days: 3          
       - name: Upload grr-api-client
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: grr-api-client
           path: /tmp/sdists/grr-api-client-[0-9]*.zip
@@ -87,7 +87,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-response-proto
         path: dist/
@@ -106,7 +106,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-response-core
         path: dist/
@@ -125,7 +125,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-response-client
         path: dist/
@@ -144,7 +144,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-response-client-builder
         path: dist/
@@ -163,7 +163,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-response-server
         path: dist/
@@ -182,7 +182,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-response-test
         path: dist/
@@ -201,7 +201,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-colab
         path: dist/
@@ -220,7 +220,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
     - name: Download the artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: grr-api-client
         path: dist/


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build.yml, publish-pypi.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | build.yml, publish-pypi.yml |
| `actions/setup-node` | [`v3`](https://github.com/actions/setup-node/releases/tag/v3), [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | build.yml, publish-pypi.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | build.yml, publish-pypi.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | build.yml, publish-pypi.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
