### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_REPOSITORY }}
       - name: Build and export
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -92,7 +92,7 @@ jobs:
         name: grr-response-proto
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
 
   publish-to-pypi-grr-response-core:
     name: Publish grr-response-core to PyPI
@@ -111,7 +111,7 @@ jobs:
         name: grr-response-core
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
 
   publish-to-pypi-grr-response-client:
     name: Publish grr-response-client to PyPI
@@ -130,7 +130,7 @@ jobs:
         name: grr-response-client
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
 
   publish-to-pypi-grr-response-client-builder:
     name: Publish grr-response-client-builder to PyPI
@@ -149,7 +149,7 @@ jobs:
         name: grr-response-client-builder
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
 
   publish-to-pypi-grr-response-server:
     name: Publish grr-response-server to PyPI
@@ -168,7 +168,7 @@ jobs:
         name: grr-response-server
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
 
   publish-to-pypi-grr-response-test:
     name: Publish grr-response-test to PyPI
@@ -187,7 +187,7 @@ jobs:
         name: grr-response-test
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
 
   publish-to-pypi-grr-colab:
     name: Publish grr-colab to PyPI
@@ -206,7 +206,7 @@ jobs:
         name: grr-colab
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
 
   publish-to-pypi-grr-api-client:
     name: Publish grr-api-client to PyPI
@@ -225,4 +225,4 @@ jobs:
         name: grr-api-client
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -92,7 +92,7 @@ jobs:
         name: grr-response-proto
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
 
   publish-to-pypi-grr-response-core:
     name: Publish grr-response-core to PyPI
@@ -111,7 +111,7 @@ jobs:
         name: grr-response-core
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
 
   publish-to-pypi-grr-response-client:
     name: Publish grr-response-client to PyPI
@@ -130,7 +130,7 @@ jobs:
         name: grr-response-client
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
 
   publish-to-pypi-grr-response-client-builder:
     name: Publish grr-response-client-builder to PyPI
@@ -149,7 +149,7 @@ jobs:
         name: grr-response-client-builder
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
 
   publish-to-pypi-grr-response-server:
     name: Publish grr-response-server to PyPI
@@ -168,7 +168,7 @@ jobs:
         name: grr-response-server
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
 
   publish-to-pypi-grr-response-test:
     name: Publish grr-response-test to PyPI
@@ -187,7 +187,7 @@ jobs:
         name: grr-response-test
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
 
   publish-to-pypi-grr-colab:
     name: Publish grr-colab to PyPI
@@ -206,7 +206,7 @@ jobs:
         name: grr-colab
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
 
   publish-to-pypi-grr-api-client:
     name: Publish grr-api-client to PyPI
@@ -225,4 +225,4 @@ jobs:
         name: grr-api-client
         path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Files |
|--------|---------------|-------------|-------|
| `docker/build-push-action` | `v5` | `v6` | workflow files |
| `pypa/gh-action-pypi-publish` | `release/v1` | [`ed0c539`](https://github.com/pypa/gh-action-pypi-publish/commit/ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e) | workflow files |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Note on pypa/gh-action-pypi-publish

This action uses **branch-based versioning** (`release/v1.x`) rather than tags. The `v1` tag does not exist in this repository. 

This PR pins to the SHA of `release/v1.13` for security best practices:
```yaml
uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13
```

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality.
