### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/grr/config/grr_response_templates/upload.sh
+++ b/grr/config/grr_response_templates/upload.sh
@@ -22,13 +22,13 @@ fi
 md5fingerprint=$(md5sum "${RELEASE_FILE}" | cut -d" " -f1)
 
 # Upload tarball, make public
-gsutil cp "${RELEASE_FILE}" "gs://${BUCKET}/"
-gsutil acl ch -u AllUsers:R "gs://${BUCKET}/${RELEASE_TAR}"
+gcloud storage cp "${RELEASE_FILE}" "gs://${BUCKET}/"
+gcloud storage objects update "gs://${BUCKET}/${RELEASE_TAR}" --add-acl-grant=entity=allUsers,role=READER
 
 sed -i -e "s!</body></html>!<a href=\"${RELEASE_TAR}#md5=${md5fingerprint}\">${RELEASE_NAME}</a><br/>\n</body></html>!" index.html
 
-gsutil cp index.html "gs://${BUCKET}/"
-gsutil acl ch -u AllUsers:R "gs://${BUCKET}/index.html"
+gcloud storage cp index.html "gs://${BUCKET}/"
+gcloud storage objects update "gs://${BUCKET}/index.html" --add-acl-grant=entity=allUsers,role=READER
 
 echo "Test install with:"
 echo "pip install --no-cache-dir -f https://storage.googleapis.com/${BUCKET}/index.html grr-response-templates==${VERSION}"

--- a/terraform/demo/google/server_startup.sh
+++ b/terraform/demo/google/server_startup.sh
@@ -6,7 +6,7 @@ LINUX_INSTALLER_UPLOAD_URL=$(curl http://metadata.google.internal/computeMetadat
 if [[ "${grr_version}" = "latest" ]]; then
   wget "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-273.0.0-linux-x86_64.tar.gz"
   tar -xzf ./google-cloud-sdk-273.0.0-linux-x86_64.tar.gz -C .
-  ./google-cloud-sdk/bin/gsutil cp gs://autobuilds.grr-response.com/_latest_server_deb/*.deb .
+  ./google-cloud-sdk/bin/gcloud storage cp gs://autobuilds.grr-response.com/_latest_server_deb/*.deb .
   GRR_VERSION=$(ls *.deb | sed 's/.*\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)\-\([0-9]\+\).*/\1.\2.\3.\4/')
 else
   GRR_VERSION="${grr_version}"


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
