### PR TITLE
Pyinstaller workaround for `ipaddress`

### DIFF
--- a/grr/client_builder/grr_response_client_builder/build_helpers.py
+++ b/grr/client_builder/grr_response_client_builder/build_helpers.py
@@ -147,6 +147,9 @@ def BuildWithPyInstaller(context=None):
       config.CONFIG.Get("PyInstaller.workpath_dir", context=context),
       spec_file,
   ]
+  # Pyinstaller does ignore the 'ipaddress' library.
+  # The below line is a workaround to force pyinstaller to include it.
+  PyInstallerMain.compat.PY3_BASE_MODULES.add('ipaddress')
   logging.info("Running pyinstaller: %s", args)
   PyInstallerMain.run(pyi_args=args)
 


### PR DESCRIPTION
Re-apply changes from https://github.com/google/grr/pull/1129