### PR TITLE
fix: harden robot router GetFileBlob access validation

### DIFF
--- a/grr/server/grr_response_server/gui/api_call_robot_router.py
+++ b/grr/server/grr_response_server/gui/api_call_robot_router.py
@@ -286,15 +286,14 @@ class ApiCallRobotRouter(api_call_router.ApiCallRouterStub):
     """
     flows = data_store.REL_DB.ReadAllFlowObjects(
         client_id=str(client_id),
+        created_by=frozenset([context.username]),
         include_child_flows=False,
     )
-    for flow_obj in flows:
-      if flow_obj.creator == context.username:
-        return
-    raise access_control.UnauthorizedAccess(
-        "Robot user %s has no flows on client %s."
-        % (context.username, client_id)
-    )
+    if not flows:
+      raise access_control.UnauthorizedAccess(
+          "Robot user %s has no flows on client %s."
+          % (context.username, client_id)
+      )
 
   def _FixFileFinderArgs(
       self, source_args: any_pb2.Any

--- a/grr/server/grr_response_server/gui/api_call_robot_router.py
+++ b/grr/server/grr_response_server/gui/api_call_robot_router.py
@@ -277,6 +277,25 @@ class ApiCallRobotRouter(api_call_router.ApiCallRouterStub):
       )
     return flow_obj.flow_class_name
 
+  def _CheckClientRobotAccess(self, client_id, context=None):
+    """Verify the requesting user has at least one flow on this client.
+
+    Used for endpoints that take a client_id but no flow_id, such as
+    GetFileBlob.  This ensures the robot user has some prior relationship
+    with the client, consistent with the per-flow checks on other methods.
+    """
+    flows = data_store.REL_DB.ReadAllFlowObjects(
+        client_id=str(client_id),
+        include_child_flows=False,
+    )
+    for flow_obj in flows:
+      if flow_obj.creator == context.username:
+        return
+    raise access_control.UnauthorizedAccess(
+        "Robot user %s has no flows on client %s."
+        % (context.username, client_id)
+    )
+
   def _FixFileFinderArgs(
       self, source_args: any_pb2.Any
   ) -> flows_pb2.FileFinderArgs:
@@ -462,6 +481,8 @@ class ApiCallRobotRouter(api_call_router.ApiCallRouterStub):
       raise access_control.UnauthorizedAccess(
           "GetFileBlob is not allowed by the configuration."
       )
+
+    self._CheckClientRobotAccess(args.client_id, context=context)
 
     return api_vfs.ApiGetFileBlobHandler()
 

--- a/grr/server/grr_response_server/gui/api_call_robot_router_test.py
+++ b/grr/server/grr_response_server/gui/api_call_robot_router_test.py
@@ -12,6 +12,7 @@ from grr_response_proto import flows_pb2
 from grr_response_proto import timeline_pb2
 from grr_response_proto.api import flow_pb2 as api_flow_pb2
 from grr_response_proto.api import timeline_pb2 as api_timeline_pb2
+from grr_response_proto.api import vfs_pb2 as api_vfs_pb2
 from grr_response_server import access_control
 from grr_response_server import flow_base
 from grr_response_server.flows.general import collectors
@@ -701,6 +702,44 @@ class ApiCallRobotRouterTest(acl_test_lib.AclTestMixin, test_lib.GRRBaseTest):
     )
     with self.assertRaises(access_control.UnauthorizedAccess):
       router.GetFileBlob(None, context=self.context)
+
+  def testGetFileBlobRaisesIfNoFlowCreatedBySameUser(self):
+    flow_test_lib.StartFlow(
+        file_finder.FileFinder, self.client_id, creator=self.another_username
+    )
+
+    router = rr.ApiCallRobotRouter(
+        params=api_call_router_pb2.ApiCallRobotRouterParams(
+            get_file_blob=api_call_router_pb2.RobotRouterGetFileBlobParams(
+                enabled=True
+            )
+        )
+    )
+    with self.assertRaises(access_control.UnauthorizedAccess):
+      router.GetFileBlob(
+          api_vfs_pb2.ApiGetFileBlobArgs(
+              client_id=self.client_id, file_path="fs/os/etc/passwd"
+          ),
+          context=self.context,
+      )
+
+  def testGetFileBlobWorksIfFlowWasCreatedBySameUser(self):
+    self._CreateFlowWithRobotId()
+
+    router = rr.ApiCallRobotRouter(
+        params=api_call_router_pb2.ApiCallRobotRouterParams(
+            get_file_blob=api_call_router_pb2.RobotRouterGetFileBlobParams(
+                enabled=True
+            )
+        )
+    )
+    # Should not raise -- the requesting user has a flow on this client.
+    router.GetFileBlob(
+        api_vfs_pb2.ApiGetFileBlobArgs(
+            client_id=self.client_id, file_path="fs/os/etc/passwd"
+        ),
+        context=self.context,
+    )
 
   def testGetFlowFilesArchiveIsDisabledByDefault(self):
     router = rr.ApiCallRobotRouter(


### PR DESCRIPTION
## Summary
- Add client-level access check to `GetFileBlob` in `ApiCallRobotRouter`
- New `_CheckClientRobotAccess` verifies the requesting user has at least one flow on the target client
- Consistent with the per-flow checks (`_CheckFlowRobotId`) on other data-retrieval methods in the same router
- Adds two tests: rejection when no flow exists, success when flow exists

## Test plan
- [x] `testGetFileBlobRaisesIfNoFlowCreatedBySameUser` -- another user's flow does not grant access
- [x] `testGetFileBlobWorksIfFlowWasCreatedBySameUser` -- own flow grants access
- [x] Existing `testGetFileBlobIsDisabledByDefault` unaffected