### PR TITLE
Harden ListScheduledFlows access control

### DIFF
--- a/grr/server/grr_response_server/gui/api_call_router_with_approval_checks.py
+++ b/grr/server/grr_response_server/gui/api_call_router_with_approval_checks.py
@@ -709,6 +709,7 @@ class ApiCallRouterWithApprovalChecks(api_call_router.ApiCallRouterStub):
       args: api_flow_pb2.ApiListScheduledFlowsArgs,
       context: Optional[api_call_context.ApiCallContext] = None,
   ) -> api_flow.ApiListScheduledFlowsHandler:
+    self.approval_checker.CheckClientAccess(context, args.client_id)
     return self.delegate.ListScheduledFlows(args, context=context)
 
   def UnscheduleFlow(

--- a/grr/server/grr_response_server/gui/api_call_router_with_approval_checks_test.py
+++ b/grr/server/grr_response_server/gui/api_call_router_with_approval_checks_test.py
@@ -382,6 +382,7 @@ class ApiCallRouterWithApprovalChecksTest(
       "ListAllFlowOutputPluginLogs",
       "ListFlowLogs",
       "ScheduleFlow",
+      "ListScheduledFlows",
   ])
 
   def testClientFlowsMethodsAreAccessChecked(self):
@@ -413,6 +414,13 @@ class ApiCallRouterWithApprovalChecksTest(
         "CheckIfHasAccessToFlow",
         access_checker_mock=self.mitigation_flows_access_checker_mock,
         args=args,
+    )
+
+    args = api_flow_pb2.ApiListScheduledFlowsArgs(
+        client_id=self.client_id, creator="test"
+    )
+    self.CheckMethodIsAccessChecked(
+        self.router.ListScheduledFlows, "CheckClientAccess", args=args
     )
 
     args = api_flow_pb2.ApiCancelFlowArgs(client_id=self.client_id)

--- a/grr/server/grr_response_server/gui/api_plugins/flow.py
+++ b/grr/server/grr_response_server/gui/api_plugins/flow.py
@@ -1411,8 +1411,10 @@ class ApiListScheduledFlowsHandler(api_call_handler_base.ApiCallHandler):
       args: flow_pb2.ApiListScheduledFlowsArgs,
       context: Optional[api_call_context.ApiCallContext] = None,
   ) -> flow_pb2.ApiListScheduledFlowsResult:
+    assert context is not None
+
     results = flow.ListScheduledFlows(
-        client_id=args.client_id, creator=args.creator
+        client_id=args.client_id, creator=context.username
     )
     results = sorted(results, key=lambda sf: sf.create_time)
     results = [InitApiScheduledFlowFromScheduledFlow(sf) for sf in results]

--- a/grr/server/grr_response_server/gui/api_plugins/flow_test.py
+++ b/grr/server/grr_response_server/gui/api_plugins/flow_test.py
@@ -867,6 +867,34 @@ class ApiScheduleFlowsTest(absltest.TestCase):
     self.assertCountEqual(results.scheduled_flows, [sf1, sf2])
 
   @db_test_lib.WithDatabase
+  def testListScheduledFlowsUsesContextUsername(
+      self, db: abstract_db.Database
+  ):
+    """Verify that handler uses context.username, not args.creator."""
+    context = _CreateContext(db)
+    client_id = db_test_utils.InitializeClient(db)
+
+    # Schedule a flow as the authenticated user.
+    handler = flow_plugin.ApiScheduleFlowHandler()
+    args = flow_pb2.ApiCreateFlowArgs()
+    args.client_id = client_id
+    args.flow.name = file.CollectFilesByKnownPath.__name__
+    args.flow.args.Pack(flows_pb2.CollectFilesByKnownPathArgs(paths=["/foo"]))
+    args.flow.runner_args.CopyFrom(flows_pb2.FlowRunnerArgs(cpu_limit=60))
+    sf = handler.Handle(args, context=context)
+
+    # List with args.creator set to a different user -- the handler should
+    # ignore it and use context.username instead.
+    handler = flow_plugin.ApiListScheduledFlowsHandler()
+    args = flow_pb2.ApiListScheduledFlowsArgs(
+        client_id=client_id, creator="someotheruser"
+    )
+    results = handler.Handle(args, context=context)
+
+    # Should still return the authenticated user's flows, not "someotheruser".
+    self.assertCountEqual(results.scheduled_flows, [sf])
+
+  @db_test_lib.WithDatabase
   def testUnscheduleFlowRemovesScheduledFlow(self, db: abstract_db.Database):
     context = _CreateContext(db)
     client_id = db_test_utils.InitializeClient(db)


### PR DESCRIPTION
## Summary

- Add missing `CheckClientAccess` call to `ListScheduledFlows` in the approval-checks router, consistent with all other client-scoped methods.
- Use `context.username` instead of `args.creator` in the handler to scope listing to the authenticated user.
- Add tests for both changes.