### PR TITLE
feat: add created_by filter to ReadAllFlowObjects

### DIFF
--- a/grr/server/grr_response_server/databases/db.py
+++ b/grr/server/grr_response_server/databases/db.py
@@ -2061,7 +2061,7 @@ class Database(metaclass=abc.ABCMeta):
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
-      created_by: Optional[str] = None,
+      created_by: Optional[Iterable[str]] = None,
   ) -> list[flows_pb2.Flow]:
     """Returns all flow objects.
 
@@ -2073,7 +2073,7 @@ class Database(metaclass=abc.ABCMeta):
       include_child_flows: include child flows in the results. If False, only
         parent flows are returned. Must be `True` if the parent flow is given.
       not_created_by: exclude flows created by any of the users in this list.
-      created_by: only include flows created by this user.
+      created_by: only include flows created by any of the users in this list.
 
     Returns:
       A list of Flow objects.
@@ -4336,7 +4336,7 @@ class DatabaseValidationWrapper(Database):
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
-      created_by: Optional[str] = None,
+      created_by: Optional[Iterable[str]] = None,
   ) -> list[flows_pb2.Flow]:
     if client_id is not None:
       precondition.ValidateClientId(client_id)
@@ -4352,7 +4352,7 @@ class DatabaseValidationWrapper(Database):
       precondition.AssertIterableType(not_created_by, str)
 
     if created_by is not None:
-      precondition.AssertType(created_by, str)
+      precondition.AssertIterableType(created_by, str)
 
     return self.delegate.ReadAllFlowObjects(
         client_id=client_id,

--- a/grr/server/grr_response_server/databases/db.py
+++ b/grr/server/grr_response_server/databases/db.py
@@ -2061,6 +2061,7 @@ class Database(metaclass=abc.ABCMeta):
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
+      created_by: Optional[str] = None,
   ) -> list[flows_pb2.Flow]:
     """Returns all flow objects.
 
@@ -2072,6 +2073,7 @@ class Database(metaclass=abc.ABCMeta):
       include_child_flows: include child flows in the results. If False, only
         parent flows are returned. Must be `True` if the parent flow is given.
       not_created_by: exclude flows created by any of the users in this list.
+      created_by: only include flows created by this user.
 
     Returns:
       A list of Flow objects.
@@ -4334,6 +4336,7 @@ class DatabaseValidationWrapper(Database):
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
+      created_by: Optional[str] = None,
   ) -> list[flows_pb2.Flow]:
     if client_id is not None:
       precondition.ValidateClientId(client_id)
@@ -4348,6 +4351,9 @@ class DatabaseValidationWrapper(Database):
     if not_created_by is not None:
       precondition.AssertIterableType(not_created_by, str)
 
+    if created_by is not None:
+      precondition.AssertType(created_by, str)
+
     return self.delegate.ReadAllFlowObjects(
         client_id=client_id,
         parent_flow_id=parent_flow_id,
@@ -4355,6 +4361,7 @@ class DatabaseValidationWrapper(Database):
         max_create_time=max_create_time,
         include_child_flows=include_child_flows,
         not_created_by=not_created_by,
+        created_by=created_by,
     )
 
   def ReadChildFlowObjects(

--- a/grr/server/grr_response_server/databases/db_flows_test.py
+++ b/grr/server/grr_response_server/databases/db_flows_test.py
@@ -443,6 +443,29 @@ class DatabaseTestFlowMixin(object):
     flows = self.db.ReadAllFlowObjects(not_created_by=frozenset(["baz", "foo"]))
     self.assertCountEqual([f.flow_id for f in flows], ["000A0002"])
 
+  def testReadAllFlowObjectsWithCreatedBy(self):
+    client_id_1 = "C.1111111111111111"
+    self.db.WriteClientMetadata(client_id_1)
+
+    self.db.WriteFlowObject(
+        flows_pb2.Flow(client_id=client_id_1, flow_id="000A0001", creator="foo")
+    )
+    self.db.WriteFlowObject(
+        flows_pb2.Flow(client_id=client_id_1, flow_id="000A0002", creator="bar")
+    )
+    self.db.WriteFlowObject(
+        flows_pb2.Flow(client_id=client_id_1, flow_id="000A0003", creator="foo")
+    )
+
+    flows = self.db.ReadAllFlowObjects(created_by="foo")
+    self.assertCountEqual([f.flow_id for f in flows], ["000A0001", "000A0003"])
+
+    flows = self.db.ReadAllFlowObjects(created_by="bar")
+    self.assertCountEqual([f.flow_id for f in flows], ["000A0002"])
+
+    flows = self.db.ReadAllFlowObjects(created_by="nonexistent")
+    self.assertEmpty(flows)
+
   def testReadAllFlowObjectsWithAllConditions(self):
     client_id_1 = "C.1111111111111111"
     client_id_2 = "C.2222222222222222"

--- a/grr/server/grr_response_server/databases/db_flows_test.py
+++ b/grr/server/grr_response_server/databases/db_flows_test.py
@@ -457,13 +457,18 @@ class DatabaseTestFlowMixin(object):
         flows_pb2.Flow(client_id=client_id_1, flow_id="000A0003", creator="foo")
     )
 
-    flows = self.db.ReadAllFlowObjects(created_by="foo")
+    flows = self.db.ReadAllFlowObjects(created_by=frozenset(["foo"]))
     self.assertCountEqual([f.flow_id for f in flows], ["000A0001", "000A0003"])
 
-    flows = self.db.ReadAllFlowObjects(created_by="bar")
+    flows = self.db.ReadAllFlowObjects(created_by=frozenset(["bar"]))
     self.assertCountEqual([f.flow_id for f in flows], ["000A0002"])
 
-    flows = self.db.ReadAllFlowObjects(created_by="nonexistent")
+    flows = self.db.ReadAllFlowObjects(created_by=frozenset(["foo", "bar"]))
+    self.assertCountEqual(
+        [f.flow_id for f in flows], ["000A0001", "000A0002", "000A0003"]
+    )
+
+    flows = self.db.ReadAllFlowObjects(created_by=frozenset(["nonexistent"]))
     self.assertEmpty(flows)
 
   def testReadAllFlowObjectsWithAllConditions(self):

--- a/grr/server/grr_response_server/databases/mem_flows.py
+++ b/grr/server/grr_response_server/databases/mem_flows.py
@@ -239,7 +239,7 @@ class InMemoryDBFlowMixin(object):
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
-      created_by: Optional[str] = None,
+      created_by: Optional[Iterable[str]] = None,
   ) -> list[flows_pb2.Flow]:
     """Returns all flow objects."""
     res = []
@@ -262,7 +262,7 @@ class InMemoryDBFlowMixin(object):
         continue
       if not_created_by is not None and flow.creator in list(not_created_by):
         continue
-      if created_by is not None and flow.creator != created_by:
+      if created_by is not None and flow.creator not in list(created_by):
         continue
       res.append(flow)
     return res

--- a/grr/server/grr_response_server/databases/mem_flows.py
+++ b/grr/server/grr_response_server/databases/mem_flows.py
@@ -239,6 +239,7 @@ class InMemoryDBFlowMixin(object):
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
+      created_by: Optional[str] = None,
   ) -> list[flows_pb2.Flow]:
     """Returns all flow objects."""
     res = []
@@ -260,6 +261,8 @@ class InMemoryDBFlowMixin(object):
       if not include_child_flows and flow.parent_flow_id:
         continue
       if not_created_by is not None and flow.creator in list(not_created_by):
+        continue
+      if created_by is not None and flow.creator != created_by:
         continue
       res.append(flow)
     return res

--- a/grr/server/grr_response_server/databases/mysql_flows.py
+++ b/grr/server/grr_response_server/databases/mysql_flows.py
@@ -407,7 +407,7 @@ class MySQLDBFlowMixin:
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
-      created_by: Optional[str] = None,
+      created_by: Optional[Iterable[str]] = None,
       cursor: Optional[cursors.Cursor] = None,
   ) -> list[flows_pb2.Flow]:
     """Returns all flow objects."""
@@ -443,8 +443,8 @@ class MySQLDBFlowMixin:
       args.append(list(not_created_by))
 
     if created_by is not None:
-      conditions.append("creator = %s")
-      args.append(created_by)
+      conditions.append("creator IN %s")
+      args.append(list(created_by))
 
     query = f"SELECT {self.FLOW_DB_FIELDS} FROM flows"
     if conditions:

--- a/grr/server/grr_response_server/databases/mysql_flows.py
+++ b/grr/server/grr_response_server/databases/mysql_flows.py
@@ -407,6 +407,7 @@ class MySQLDBFlowMixin:
       max_create_time: Optional[rdfvalue.RDFDatetime] = None,
       include_child_flows: bool = True,
       not_created_by: Optional[Iterable[str]] = None,
+      created_by: Optional[str] = None,
       cursor: Optional[cursors.Cursor] = None,
   ) -> list[flows_pb2.Flow]:
     """Returns all flow objects."""
@@ -440,6 +441,10 @@ class MySQLDBFlowMixin:
       # implementation does not know how to convert a `frozenset` to a string.
       # The cursor implementation knows how to convert lists and ordinary sets.
       args.append(list(not_created_by))
+
+    if created_by is not None:
+      conditions.append("creator = %s")
+      args.append(created_by)
 
     query = f"SELECT {self.FLOW_DB_FIELDS} FROM flows"
     if conditions:


### PR DESCRIPTION
## Summary
- Add optional `created_by` parameter to `ReadAllFlowObjects` for filtering flows by creator at the database level
- Implemented in both MySQL and in-memory backends, with input validation in `ValidatingDB`
- Allows callers to efficiently query flows for a specific user without fetching all flows first

Companion to #1162, which currently iterates all flows in Python to find one owned by the requesting user.

## Test plan
- [x] `testReadAllFlowObjectsWithCreatedBy` covers match, single-match, and no-match cases
- [x] Existing `testReadAllFlowObjectsWithNotCreatedBy` and `testReadAllFlowObjectsWithAllConditions` unaffected